### PR TITLE
Removed stray double-quote after jquery <script> call

### DIFF
--- a/_layout.ejs
+++ b/_layout.ejs
@@ -17,7 +17,7 @@
         </div>
       </div>
     </div>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>"
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
     <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.5/highlight.min.js"></script>
     <script src="/javascript/codehighlight.js"></script>
     <script>hljs.initHighlightingOnLoad();</script>


### PR DESCRIPTION
It was a bug!

![](http://f.cl.ly/items/030i2m2F3h1U3N2U2a0y/Screen%20Shot%202015-04-23%20at%201.57.45%20PM.png)
