### PR TITLE
changed responsive grid cols to have xs-col

### DIFF
--- a/layout/grid.ejs
+++ b/layout/grid.ejs
@@ -210,9 +210,9 @@
   <div class="clearfix mt2 text-gray-lightest type-5">
     <label class="col sm-col-12 text-gray-lightest">.col .xs-col-12 .md-col-6 .lg-col-3</label>
     <div class="col xs-col-12 md-col-6 lg-col-3 border rounded p2 fill-gray-lighter"></div>
-    <div class="col sm-col-12 md-col-6 lg-col-3 border rounded p2 fill-gray-lighter"></div>
-    <div class="col sm-col-12 md-col-6 lg-col-3 border rounded p2 fill-gray-lighter"></div>
-    <div class="col sm-col-12 md-col-6 lg-col-3 border rounded p2 fill-gray-lighter"></div>
+    <div class="col xs-col-12 md-col-6 lg-col-3 border rounded p2 fill-gray-lighter"></div>
+    <div class="col xs-col-12 md-col-6 lg-col-3 border rounded p2 fill-gray-lighter"></div>
+    <div class="col xs-col-12 md-col-6 lg-col-3 border rounded p2 fill-gray-lighter"></div>
   </div> 
 
 </div> 


### PR DESCRIPTION
line 212-215 in grid.ejs should all have xs-col

expected/desired

```
    <div class="col xs-col-12 md-col-6 lg-col-3 border rounded p2 fill-gray-lighter"></div>
    <div class="col xs-col-12 md-col-6 lg-col-3 border rounded p2 fill-gray-lighter"></div>
    <div class="col xs-col-12 md-col-6 lg-col-3 border rounded p2 fill-gray-lighter"></div>
    <div class="col xs-col-12 md-col-6 lg-col-3 border rounded p2 fill-gray-lighter"></div>
```
