### PR TITLE
fixed size of h6 to 0.75rem

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -56,6 +56,6 @@ $type-2:  1.375rem;  // 16px
 $type-3:  1.125rem;  // 16px
 $type-4:  1rem;      // 16px
 $type-5:  0.875rem;   // 12px
-$type-6:  0.625rem;  // 10px
+$type-6:  0.75rem;  // 10px
 
 $line-height: 1.1;   // 1.1x the font-size


### PR DESCRIPTION
Hey guys, just need to get an OK to merge this back into master

The size of h6 was wrong in variables.scss

Correct is https://www.dropbox.com/s/kc03hpreb3ouvtv/Screenshot%202015-05-11%2014.43.14.png?dl=0
