### PR TITLE
changed styling for the js highlight class and removed old code on ty…

### DIFF
--- a/scss/_solid-specific.scss
+++ b/scss/_solid-specific.scss
@@ -11,12 +11,8 @@ code {
 
   // Inline code blocks
   &.js-highlight {
-    border: $border;
     display: inline-block;
-    padding: 2px 4px;
-    border-radius: 2px;
-    background-color: $fill-gray--lighter;
-    font-size: $type-6;
+    font-size: $type-5;
     color: $js-highlight-magenta;
   }
   

--- a/scss/typography/_typography.scss
+++ b/scss/typography/_typography.scss
@@ -43,13 +43,8 @@ h5 {
   font-size: $type-5;
 }
 
-h6,
-.type-6 {
+h6 {
   font-size: $type-6;
-
-  &.slab {
-    font-family: "Proxima-Nova";
-  }
 }
 
 // wouldn't it make more sense to @extend .link-blue; here? 
@@ -184,7 +179,7 @@ i,
   }
 }
 
-// Caponi should never be an h6 or .type-6
+// Caponi should never be an h6 or .type-6, these classes disallow that from happening (type will default to Proxima)
 
 // scss-lint:disable QualifyingElement
 .slab h6,


### PR DESCRIPTION
Changed the JS highlight class so that there is no background or border on type styled with that class. 
![image](https://cloud.githubusercontent.com/assets/586552/8826543/400f0b0c-3055-11e5-8545-74d24ab67add.png)

Changed the size of the class from $type-6 to $type-5

Also, this old code was hanging around, I removed it a while ago but I think it popped back up in a rebase 

![image](https://cloud.githubusercontent.com/assets/586552/8826520/10435428-3055-11e5-9ac9-f223abc3b6be.png)

Because the type variable is defined above, and the slab class override below, this is not necessary. 

It should read: 

```
h6 {
  font-size: $type-6;
}
```
