### PR TITLE
Removing extra white space from block-grid-item elements

### DIFF
--- a/layout/block-grid.ejs
+++ b/layout/block-grid.ejs
@@ -14,8 +14,8 @@
           <p class="text-6 text-gray--lighter">Javier Moreno, 3 weeks ago</p>
         </div>
       </div>
-    </li><!--
-    --><li class="block-grid-item">
+    </li>
+    <li class="block-grid-item">
       <div class="fill-white border">
         <img src="http://s3-static-ak.buzzfed.com/static/2015-07/7/19/campaign_images/webdr02/the-sorting-hat-quiz-hogwarts-2-16400-1436310166-16_wide.jpg">
         <div class="p1">
@@ -23,8 +23,8 @@
           <p class="text-6 text-gray--lighter">Javier Moreno, One week ago</p>
         </div>
       </div>
-    </li><!--
-    --><li class="block-grid-item">
+    </li>
+    <li class="block-grid-item">
       <div class="fill-white border">
         <img src="http://s3-static-ak.buzzfed.com/static/2015-06/27/11/campaign_images/webdr10/which-animal-matches-your-personality-2-22744-1435420255-2_wide.jpg">
         <div class="p1">
@@ -32,8 +32,8 @@
           <p class="text-6 text-gray--lighter">Javier Moreno, 3 weeks ago</p>
         </div>
       </div>
-    </li><!--
-    --><li class="block-grid-item">
+    </li>
+    <li class="block-grid-item">
       <div class="fill-white border">
         <img src="http://s3-static-ak.buzzfed.com/static/2015-07/7/19/campaign_images/webdr02/the-sorting-hat-quiz-hogwarts-2-16400-1436310166-16_wide.jpg">
         <div class="p1">
@@ -41,8 +41,8 @@
           <p class="text-6 text-gray--lighter">Javier Moreno, One week ago</p>
         </div>
       </div>
-    </li><!--
-    --><li class="block-grid-item">
+    </li>
+    <li class="block-grid-item">
       <div class="fill-white border">
         <img src="http://s3-static-ak.buzzfed.com/static/2015-06/27/11/campaign_images/webdr10/which-animal-matches-your-personality-2-22744-1435420255-2_wide.jpg">
         <div class="p1">
@@ -50,8 +50,8 @@
           <p class="text-6 text-gray--lighter">Javier Moreno, 3 weeks ago</p>
         </div>
       </div>
-    </li><!--
-    --><li class="block-grid-item">
+    </li>
+    <li class="block-grid-item">
       <div class="fill-white border">
         <img src="http://s3-static-ak.buzzfed.com/static/2015-07/7/19/campaign_images/webdr02/the-sorting-hat-quiz-hogwarts-2-16400-1436310166-16_wide.jpg">
         <div class="p1">
@@ -62,12 +62,12 @@
     </li>
   </ul>
 
-  <p class="mb2"><span class="text-red">Important note:</span> When developing a Block Grid, you'll need to place all <code class="js-highlight">block-grid-item</code> elements on the same line to avoid the extra space added automatically by the html. Here's the code:</p>
-
   <div class="mb4 pb4">
 
 <pre><code class="html"><%='<ul class="block-grid block-grid-3">'%>
-  <%='<li class="block-grid-item">Content goes here.</li><li class="block-grid-item">Content goes here.</li><li class="block-grid-item">Content goes here.</li>'%>
+  <%='<li class="block-grid-item">Content goes here.</li>'%>
+  <%='<li class="block-grid-item">Content goes here.</li>'%>
+  <%='<li class="block-grid-item">Content goes here.</li>'%>
 <%='</ul>'%></code></pre>
 
   </div>
@@ -86,8 +86,8 @@
           <p class="text-6 text-gray--lighter">Javier Moreno, 3 weeks ago</p>
         </div>
       </div>
-    </li><!--
-    --><li class="block-grid-item">
+    </li>
+    <li class="block-grid-item">
       <div class="fill-white border">
         <img src="http://s3-static-ak.buzzfed.com/static/2015-07/7/19/campaign_images/webdr02/the-sorting-hat-quiz-hogwarts-2-16400-1436310166-16_wide.jpg">
         <div class="p1">
@@ -95,8 +95,8 @@
           <p class="text-6 text-gray--lighter">Javier Moreno, One week ago</p>
         </div>
       </div>
-    </li><!--
-    --><li class="block-grid-item">
+    </li>
+    <li class="block-grid-item">
       <div class="fill-white border">
         <img src="http://s3-static-ak.buzzfed.com/static/2015-06/27/11/campaign_images/webdr10/which-animal-matches-your-personality-2-22744-1435420255-2_wide.jpg">
         <div class="p1">
@@ -104,8 +104,8 @@
           <p class="text-6 text-gray--lighter">Javier Moreno, 3 weeks ago</p>
         </div>
       </div>
-    </li><!--
-    --><li class="block-grid-item">
+    </li>
+    <li class="block-grid-item">
       <div class="fill-white border">
         <img src="http://s3-static-ak.buzzfed.com/static/2015-07/7/19/campaign_images/webdr02/the-sorting-hat-quiz-hogwarts-2-16400-1436310166-16_wide.jpg">
         <div class="p1">
@@ -113,8 +113,8 @@
           <p class="text-6 text-gray--lighter">Javier Moreno, One week ago</p>
         </div>
       </div>
-    </li><!--
-    --><li class="block-grid-item">
+    </li>
+    <li class="block-grid-item">
       <div class="fill-white border">
         <img src="http://s3-static-ak.buzzfed.com/static/2015-06/27/11/campaign_images/webdr10/which-animal-matches-your-personality-2-22744-1435420255-2_wide.jpg">
         <div class="p1">
@@ -122,8 +122,8 @@
           <p class="text-6 text-gray--lighter">Javier Moreno, 3 weeks ago</p>
         </div>
       </div>
-    </li><!--
-    --><li class="block-grid-item">
+    </li>
+    <li class="block-grid-item">
       <div class="fill-white border">
         <img src="http://s3-static-ak.buzzfed.com/static/2015-07/7/19/campaign_images/webdr02/the-sorting-hat-quiz-hogwarts-2-16400-1436310166-16_wide.jpg">
         <div class="p1">
@@ -139,7 +139,9 @@
   <div class="mb4 pb4">
 
 <pre><code class="html"><%='<ul class="block-grid xs-block-grid-2 md-block-grid-3 lg-block-grid-4">'%>
-  <%='<li class="block-grid-item">Content goes here.</li><li class="block-grid-item">Content goes here.</li><li class="block-grid-item">Content goes here.</li>'%>
+  <%='<li class="block-grid-item">Content goes here.</li>'%>
+  <%='<li class="block-grid-item">Content goes here.</li>'%>
+  <%='<li class="block-grid-item">Content goes here.</li>'%>
 <%='</ul>'%></code></pre>
 
   </div>

--- a/scss/block-grid/_block-grid.scss
+++ b/scss/block-grid/_block-grid.scss
@@ -1,10 +1,12 @@
 .block-grid {
+  font-size: 0;
   margin: 0 -.5rem;
   padding: 0;
 }
 
 .block-grid-item {
   display: inline-block;
+  font-size: 1rem;
   padding: .5rem;
   vertical-align: top;
 }


### PR DESCRIPTION
With the previous implementation, users were encouraged to put every block-grid-item on the same line, or to add code comments between each <li> to fix the default space between them that gets added by the browser.

It turns out, though, that setting font-size: 0; on the parent fixes extra space issues with the block-grid without nasty tricks in the html. So, I've set font-size: 0; on .block-grid and then re-set font-size: 1rem; on each .block-grid-item.

Since there should never be any first-level child element inside of block-grid besides .block-grid-item, this should be the fix we're looking for.
