### PR TITLE
moved Meyer-esque reset up to the top

### DIFF
--- a/lib/base/_base.scss
+++ b/lib/base/_base.scss
@@ -1,52 +1,6 @@
 // Normalize Resets and Rem values
 
 
-// Ensure we only define type using our default classes.
-
-small {
-  font-size: 1rem;
-}
-
-sub,
-sup {
-  font-size: 1rem;
-}
-
-
-// Switching from ems to rems for consistency and our own sanity.
-
-sup {
-  top: -.5rem;
-}
-
-sub {
-  bottom: -.25rem;
-}
-
-code,
-kbd,
-pre,
-samp {
-  font-size: 1rem;
-}
-
-
-// We should define fieldset with classes if we're going to define it.
-
-fieldset {
-  border: 0;
-  margin: 0;
-  padding: 0;
-}
-
-
-// Making sure that bold is 600, since we use semibold instead.
-
-optgroup {
-  font-weight: 600;
-}
-
-
 // Resets
 
 html, 
@@ -136,6 +90,52 @@ video {
   font-size: 100%;
   font: inherit;
   vertical-align: baseline;
+}
+
+
+// Ensure we only define type using our default classes.
+
+small {
+  font-size: 1rem;
+}
+
+sub,
+sup {
+  font-size: 1rem;
+}
+
+
+// Switching from ems to rems for consistency and our own sanity.
+
+sup {
+  top: -.5rem;
+}
+
+sub {
+  bottom: -.25rem;
+}
+
+code,
+kbd,
+pre,
+samp {
+  font-size: 1rem;
+}
+
+
+// We should define fieldset with classes if we're going to define it.
+
+fieldset {
+  border: 0;
+  margin: 0;
+  padding: 0;
+}
+
+
+// Making sure that bold is 600, since we use semibold instead.
+
+optgroup {
+  font-weight: 600;
 }
 
 


### PR DESCRIPTION
Passed `scss-lint`.

@samthurman, this does not address your comment here:

> _Furthermore I think using that full meyer reset block is a little heavy handed and could be rethought._

This just reorders the reset so that our custom overrides work.
