### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,17 @@ This installation guide assumes that you have the [Buzzfeed webapp](https://gith
 
 Open a terminal window. Clone the repo into a new folder:
 
-`git clone https://github.com/buzzfeed/solid.git /opt/buzzfeed/solid`
+`git clone git@github.com:buzzfeed/solid.git /opt/buzzfeed/solid`
 
 Move into that directory
 
 `cd /opt/buzzfeed/solid`
+
+### Prepare required directories
+
+```bash
+[ ! -d /buzzfeed ] && sudo mkdir -p /buzzfeed && sudo chown `id -u`:`id -g` /buzzfeed
+```
 
 ### Build the app
 


### PR DESCRIPTION
I just tried to follow the "Setup the Styleguide Locally" instructions and ran into a couple of minor issues.  I think these issues might arise from me not having the traditional BuzzFeed webapp in place on my machine, and I think (hope?) the improvements below will make the setup process smoother regardless of whether a developer's is also prepared to run the webapp.

I've updated the `git clone` instructions to prefer the ssh URL, to avoid this problem:

``` bash
$ git clone https://github.com/buzzfeed/solid.git /opt/buzzfeed/solid
Cloning into '/opt/buzzfeed/solid'...
Username for 'https://github.com': ^C
$ git clone git@github.com:buzzfeed/solid.git /opt/buzzfeed/solid
Cloning into '/opt/buzzfeed/solid'...
remote: Counting objects: 3896, done.
remote: Compressing objects: 100% (18/18), done.
remote: Total 3896 (delta 5), reused 0 (delta 0), pack-reused 3878
Receiving objects: 100% (3896/3896), 4.95 MiB | 394.00 KiB/s, done.
Resolving deltas: 100% (2371/2371), done.
Checking connectivity... done.
```

And I've added a command to make sure that the required `/buzzfeed` directory is present and has the correct permissions, if necessary.
