### PR TITLE
fixed font names to be compliant with better font weight solutions

### DIFF
--- a/lib/typography/_typography.scss
+++ b/lib/typography/_typography.scss
@@ -3,8 +3,8 @@
 // --------------------------------------------------
 
 //fonts
-$sans: "Proxima-Nova", Helvetica, Arial, sans-serif;
-$slab: "Caponi-Slab-Semibold", Georgia, serif;
+$sans: "Proxima Nova", Helvetica, Arial, sans-serif;
+$slab: "Caponi Slab", Georgia, serif;
 
 html {
   font-size: 16px;
@@ -60,7 +60,7 @@ h6,
 
 // This is getting the color from $text-blue instead of $link-blue because $link-blue does not exist as a variable. .link-blue using the $text-blue variable
 a {
-  text-decoration: none; 
+  text-decoration: none;
   color: $text-blue;
 
   &:hover {


### PR DESCRIPTION
According to [Smashing Magazine](http://www.smashingmagazine.com/2013/02/setting-weights-and-styles-at-font-face-declaration/), the best solution for font weight management is called 'style linking' rule. Renamed fonts so that they complied with it.
Might have to update webapp too.
