### PR TITLE
removed reference to .segmented-button class in code example

### DIFF
--- a/interface/buttons.ejs
+++ b/interface/buttons.ejs
@@ -124,7 +124,7 @@
 
   </form>
 
-  <pre class="xs-mt2"><code class="html"><%='<div class="segmented-button">'%>
+  <pre class="xs-mt2"><code class="html"><%='<div class="button-group">'%>
   <%='<input class="button-group__radio" type="radio" id="option_1" value="option_1" name="options" checked="checked">'%>
   <%='<label class="button-group__item" for="option_1">Option 1</label>'%>
   <%='<input class="button-group__radio" type="radio" id="option_2" value="option_2" name="options">'%>


### PR DESCRIPTION
Removed reference to `.segmented-button` class in code example, and replaced it with `.button-group` class.

Easy peasy, please someone take a look.
