### PR TITLE
removed important from ol/ul styles in solid base typography

### DIFF
--- a/_lib/solid-base/_typography.scss
+++ b/_lib/solid-base/_typography.scss
@@ -84,5 +84,5 @@ i {
 // list items are block level
 ol,
 ul {
-  padding-left: $space-4 !important;
+  padding-left: $space-4;
 }


### PR DESCRIPTION
There should never be !important inside `solid-base/`
