### PR TITLE
Fixing line height on select menus

### DIFF
--- a/_lib/solid-utilities/_forms.scss
+++ b/_lib/solid-utilities/_forms.scss
@@ -50,6 +50,7 @@ $input-height-small: 2rem;
   border-radius: 0                              !important;
   padding-right: 2.5rem                         !important;
   height: $input-height                         !important;
+  line-height: 1                                !important;
 }
 
 .select--small,


### PR DESCRIPTION
added `line height: 1` to select menus 

branch: SOLID-244-fix-line-height-selects
