### PR TITLE
SOLID-288: Remove button height; fix line-height & padding to match buttons

### DIFF
--- a/_lib/solid-components/_button-groups.scss
+++ b/_lib/solid-components/_button-groups.scss
@@ -20,9 +20,8 @@
   display: inline-block;
   cursor: pointer;
   float: left;
-  padding: .625rem .875rem;
+  padding: .5rem .875rem;
   border-right: $border;
-  height: $button-height;
 
   &:hover {
     transition: background-color .3s ease 0s;
@@ -41,7 +40,7 @@
 }
 
 .button-group--small .button-group__item {
-  padding: .375rem .625rem;
-  height: $button-height-small;
-  font-size: $text-5; 
+  padding: .25rem .625rem;
+  font-size: $text-5;
+  line-height: $line-height-5;
 }

--- a/_lib/solid-utilities/_buttons.scss
+++ b/_lib/solid-utilities/_buttons.scss
@@ -34,24 +34,20 @@
   }
 }
 
-$button-height: 2.625rem;
-$button-height-small: 2rem;
-
 .button,
 .button--disabled,
 .button--small {
   @include button-reset;
   font-family: inherit          !important;
-  height: $button-height        !important;
   padding: .5rem .875rem        !important;
   font-size: $text-4            !important;
+  line-height: $line-height-4   !important;
   border-radius: $border-radius !important;
   text-decoration: none         !important;
   cursor: pointer               !important;
   display: inline-block         !important;
   border: 1px solid transparent !important;
   text-align: center            !important;
-  line-height: 1.5              !important;
 
   &:hover { transition: background-color .15s ease 0s !important; }
 }
@@ -106,9 +102,9 @@ $button-height-small: 2rem;
 }
 
 .button--small {
-  font-size: $text-5           !important;
   padding: .25rem .625rem      !important;
-  height: $button-height-small !important;
+  font-size: $text-5           !important;
+  line-height: $line-height-5  !important;
 }
 
 


### PR DESCRIPTION
I removed fixed button heights, but also had to adjust button groups to match the same `line-height` and `padding`:

![solid-288-illustration](https://cloud.githubusercontent.com/assets/875366/11902680/b5b85f24-a581-11e5-826c-aaf734c50892.png)

Also, whenever we set `font-size`, we should set `line-height`. 
