### PR TITLE
SOLID-288: Remove button/input height; fix line-height & padding to match buttons

### DIFF
--- a/_lib/solid-components/_button-groups.scss
+++ b/_lib/solid-components/_button-groups.scss
@@ -20,7 +20,7 @@
   display: inline-block;
   cursor: pointer;
   float: left;
-  padding: .5rem .875rem;
+  padding: $space-1 .875rem;
   border-right: $border;
 
   &:hover {
@@ -40,7 +40,7 @@
 }
 
 .button-group--small .button-group__item {
-  padding: .25rem .625rem;
+  padding: 0.3125rem .625rem  !important;
   font-size: $text-5;
   line-height: $line-height-5;
 }

--- a/_lib/solid-utilities/_buttons.scss
+++ b/_lib/solid-utilities/_buttons.scss
@@ -39,7 +39,7 @@
 .button--small {
   @include button-reset;
   font-family: inherit          !important;
-  padding: .5rem .875rem        !important;
+  padding: $space-1 .875rem     !important;
   font-size: $text-4            !important;
   line-height: $line-height-4   !important;
   border-radius: $border-radius !important;
@@ -102,9 +102,9 @@
 }
 
 .button--small {
-  padding: .25rem .625rem      !important;
-  font-size: $text-5           !important;
-  line-height: $line-height-5  !important;
+  padding: 0.3125rem .625rem  !important;
+  font-size: $text-5          !important;
+  line-height: $line-height-5 !important;
 }
 
 

--- a/_lib/solid-utilities/_forms.scss
+++ b/_lib/solid-utilities/_forms.scss
@@ -2,12 +2,6 @@
 // Forms Base Styles
 // --------------------------------------------------
 
-// Variables
-// -------------------------
-
-$input-height: 2.625rem;
-$input-height-small: 2rem;
-
 // Option Input Style
 // -------------------------
 // Adds some base custom styles to radio buttons and checkboxes. 
@@ -32,12 +26,12 @@ $input-height-small: 2rem;
 .textarea,
 .select,
 .date-input {
-  font-family: inherit    !important;
-  background: $fill-white !important;
-  font-size: $text-4      !important;
-  height: $input-height   !important;
-  padding: .625rem .75rem !important;
-  border: $border         !important;
+  font-family: inherit        !important;
+  background: $fill-white     !important;
+  font-size: $text-4          !important;
+  line-height: $line-height-4 !important;
+  padding: $space-1 .75rem     !important;
+  border: $border             !important;
 }
 
 .select {
@@ -49,22 +43,27 @@ $input-height-small: 2rem;
   -moz-appearance: none                         !important;
   border-radius: 0                              !important;
   padding-right: 2.5rem                         !important;
-  height: $input-height                         !important;
-  line-height: 1                                !important;
+}
+
+// Hide select arrow in IE 10+
+select::-ms-expand,
+.select::-ms-expand { 
+  display: none;
 }
 
 .select--small,
 .text-input--small,
 .date-input--small {
   font-size: $text-5          !important;
-  height: $input-height-small !important;
-  padding: $space-1 .625rem   !important;
+  line-height: $line-height-5 !important;
+  padding: 0.3125rem .625rem  !important;
 }
 
 
 .select--small {
-  padding: 0 $space-4 0 .625rem !important;
-  background-size: .5rem        !important;
+  padding-right: $space-4 !important;
+  background-position: calc(100% - 0.875rem) center !important;
+  background-size: .5rem  !important;
 }
 
 .textarea {

--- a/forms.html
+++ b/forms.html
@@ -181,13 +181,13 @@ title: Forms
   <p class="xs-mb4">Append the <span class="nowrap">.<code class="js-highlight">text-input--small</code></span> class to get a smaller version of Solid's text inputs.</p>
 
   <form class="xs-mb4">
-    <label class="form-label form-label--small">Add your website</label>
+    <label class="form-label form-label--smaller">Add your website</label>
     <input type="text" class="text-input text-input--small" placeholder="www.example.com">
   </form>
 
   {% highlight html %}<form>
-  <label class="form-label form-label--small">Choose a username</label>
-  <input type="text" class="text-input text-input--small" placeholder="www.example.com">
+  <label class="form-label form-label--smaller">Choose a username</label>
+  <input type="text" class="text-input text-input--smaller" placeholder="www.example.com">
 </form>{% endhighlight %}
 
 </section>


### PR DESCRIPTION
_Now against release1.4.0_

I removed fixed button heights, but also had to adjust button groups to match the same `line-height` and `padding`:

![solid-288-illustration](https://cloud.githubusercontent.com/assets/875366/11902680/b5b85f24-a581-11e5-826c-aaf734c50892.png)

Also, whenever we set `font-size`, we should set `line-height`. 
