### PR TITLE
Add block grid without gutters to nav

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -192,6 +192,7 @@
           <ul class="list-unstyled text-5 xs-hide sm-block">
             <li class="xs-py1"><a href="#basic-block-grid" class="xs-block xs-px3 solid-nav__subitem">Basic Block Grid</a></li>
             <li class="xs-py1"><a href="#responsive-block-grid" class="xs-block xs-px3 solid-nav__subitem">Responsive Block Grid</a></li>
+            <li class="xs-py1"><a href="#block-grid-without-gutters" class="xs-block xs-px3 solid-nav__subitem">Block Grid Without Gutters</a></li>
           </ul>
         {% endif %}
 


### PR DESCRIPTION
Simply adding a missing navigation element for the block grid without gutters.
