### PR TITLE
fixed text-5 on type docs to read 14px not 16px

### DIFF
--- a/typography.html
+++ b/typography.html
@@ -41,7 +41,7 @@ title: Typography
     <div class="xs-mb4">
       <p class="xs-mb1">
         <code class="js-highlight">h5</code>, .<code class="js-highlight">text-5</code>
-        <span class="text-5 text-gray--lightest xs-ml1">0.875rem, 16px</span>
+        <span class="text-5 text-gray--lightest xs-ml1">0.875rem, 14px</span>
       </p>
       <h5>BuzzFeed is the social news and entertainment company.</h5>   
     </div>


### PR DESCRIPTION
fixed typo that said text-4 and text-5 were both 16px :/

should this be in the release notes?
