### PR TITLE
Solid 265 prep solid to allow for better critical styles

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -10,5 +10,7 @@ port: 9000
 markdown: kramdown
 
 # Ignore
+sass:
+  style: compressed
 exclude:
     - node_modules

--- a/_lib/_solid-base.scss
+++ b/_lib/_solid-base.scss
@@ -5,7 +5,7 @@
 // helpers
 @import "solid-helpers";
 
-//imports
+// imports
 @import "solid-base/normalize";
 @import "solid-base/base";
 @import "solid-base/typography";

--- a/_lib/solid-base/_base.scss
+++ b/_lib/solid-base/_base.scss
@@ -1,92 +1,31 @@
 //
-// Base
+// Base Styles
 // --------------------------------------------------
-
 
 // Resets
 // -------------------------
 
-html, 
-body, 
-div, 
-span, 
-applet, 
-object, 
-iframe,
-h1, 
-h2, 
-h3, 
-h4, 
-h5, 
-h6, 
-p, 
-blockquote, 
+// Meyer Style Resets on Elements that
+// bring a lot of styling
 pre,
-a, 
-abbr, 
-acronym, 
-address, 
-big,
-cite,
 code,
-del,
-dfn,
-em,
-img,
-ins,
-kbd,
-q,
-s,
-samp,
-small,
-strike,
-strong,
 sub,
 sup,
-tt,
-var,
-b,
-u,
-i,
-center,
-dl,
-dt,
-dd,
-ol,
-ul,
-li,
 fieldset,
 form,
 label,
 legend,
+details,
+embed,
+menu,
+summary,
 table,
-caption,
 tbody,
 tfoot,
 thead,
 tr,
 th,
-td,
-article,
-aside,
-canvas,
-details,
-embed,
-figure,
-figcaption,
-footer,
-header,
-hgroup,
-menu,
-nav,
-output,
-ruby,
-section,
-summary,
-time,
-mark,
-audio,
-video {
+td {
   margin: 0;
   padding: 0;
   border: 0;
@@ -95,78 +34,48 @@ video {
   vertical-align: baseline;
 }
 
-// Specific Overrides
-// -------------------------
-
-// Ensure we only define type using our default classes.
-
-small {
-  font-size: $base-font-size;
-}
-
-sub,
-sup {
-  font-size: $base-font-size;
-}
-
-
-// Switching from ems to rems for consistency and our own sanity.
-
-sup {
-  top: (-$space-1);
-}
-
-sub {
-  bottom: -.25rem;
-}
-
-code,
-kbd,
-pre,
-samp {
-  font-size: $base-font-size;
-}
-
-
-// We should define fieldset with classes if we're going to define it.
-
-fieldset {
-  border: 0;
+// Remove base padding, margin, and font style
+// from elements who bring their own
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p,
+blockquote,
+figure,
+ol,
+ul,
+caption,
+dl,
+dt,
+dd,
+ol,
+ul,
+li {
   margin: 0;
   padding: 0;
+  font: inherit;
 }
 
 
-// Making sure that bold is 600, since we use semibold instead.
+// Normalize Patches
+// -------------------------
 
-optgroup {
-  font-weight: $bold;
-}
-
-
-// We should establish our own style for blockquotes.
-
+// remove quotes from blockquote
 blockquote, 
 q {
   quotes: none;
+
+  &:before,
+  &:after {
+    content: "";
+    content: none;
+  }
 }
 
-blockquote:before, 
-blockquote:after,
-q:before, 
-q:after {
-  content: "";
-  content: none;
-}
-
-body {
-  color: $text-gray;
-}
-
-a {
-  color: $text-blue;
-}
-
+// everything border box
 html {
   box-sizing: border-box;
 }
@@ -180,8 +89,58 @@ html {
 // Responsive Images
 img { max-width: 100%; height: auto; }
 
-// Overriding default iOS input style
-input {
-  -webkit-appearance: none;
-  border-radius: 0;
+
+// no border on iframes
+iframe { border: 0; }
+
+
+// Ensure we only define type using our default classes.
+small {
+  font-size: $base-font-size;
 }
+
+sub,
+sup {
+  font-size: $base-font-size;
+}
+
+
+// Switching from ems to rems for consistency and our own sanity.
+sup {
+  top: (-$space-1);
+}
+
+sub {
+  bottom: -.25rem;
+}
+
+
+code,
+kbd,
+pre,
+samp {
+  font-size: $base-font-size;
+}
+
+
+// We should define fieldset with classes if we're going to define it.
+fieldset {
+  border: 0;
+  margin: 0;
+  padding: 0;
+}
+
+
+// Making sure that bold is 600, since we use semibold instead.
+optgroup {
+  font-weight: $bold;
+}
+
+blockquote:before, 
+blockquote:after,
+q:before, 
+q:after {
+  content: "";
+  content: none;
+}
+

--- a/_lib/solid-critical.scss
+++ b/_lib/solid-critical.scss
@@ -1,0 +1,18 @@
+//
+// Solid Critical Styles
+// --------------------------------------------------
+// this import file only includes styles
+// neccesary at first paint
+
+// only output xs styles for responsive styles
+$generate-responsive-classes: false;
+
+@import "solid-helpers";
+
+// Base
+@import "solid-base/normalize";
+@import "solid-base/base";
+@import "solid-base/typography";
+
+// Utilities
+@import "solid-utilities/grid";

--- a/_lib/solid-helpers/_mixins.scss
+++ b/_lib/solid-helpers/_mixins.scss
@@ -32,16 +32,21 @@ $breakpoints: (
 // nest content inside breakpoint prefix classes
 // in the apropriate media query block
 @mixin generate-breakpoint-prefixes {
+  @if ($generate-responsive-classes == true) {
+    // generate prefixed classes
   @each $breakpoint-name, $breakpoint-value in $breakpoints {
     $breakpoint-prefix: "#{$breakpoint-name}-";
 
     @include media-query($breakpoint-name) {
       
-      // Columns
       .#{$breakpoint-prefix} {
         @content;
       }
     }
+   }
+  } @else {
+    // only return xs styles
+   .xs- { @content; }
   }
 }
 

--- a/_lib/solid-helpers/_variables.scss
+++ b/_lib/solid-helpers/_variables.scss
@@ -2,6 +2,14 @@
 // Variables
 // --------------------------------------------------
 
+// Config
+// -------------------------
+
+// set to false to make responsive
+// mixin give only xs- versions of
+// responsive classes
+$generate-responsive-classes: true !default;
+
 // Fonts
 // -------------------------
 


### PR DESCRIPTION
This branch does two things:
1) Slims down the CSS reset to not reset styles typography styles that are set immediately after the reset.
2) Adds a variable `$generate-responsive-classes`. When you turn this variable off responsive prefixes will not be generated.

These two modifications let us slim down solid enough to include on BZFD
