### PR TITLE
Solid 293 Messaging component: Add optional [x] close action

### DIFF
--- a/_lib/solid-components/_messaging.scss
+++ b/_lib/solid-components/_messaging.scss
@@ -3,9 +3,11 @@
 // --------------------------------------------------
 
 .page-message {
+  position: relative;
   margin-top: .125rem;
-  padding: .75rem;
+  padding: .75rem $space-4 .75rem .75rem;
   font-size: $text-4;
+  line-height: $line-height-4;
   font-weight: $bold;
 }
 
@@ -29,9 +31,10 @@
 }
 
 .page-message__delete {
-  float: right;
-  padding: .2rem .4rem;
-  margin: -.2rem -.4rem;
+  position: absolute;
+  top: $space-1;
+  right: $space-1;
+  padding: .1875rem .375rem;
   cursor: pointer;
 }
 
@@ -52,6 +55,10 @@
       background-image: svg-background($exclamation-circle);
       background-size: 1rem;
     }
+  }
+
+  .page-message__action:hover {
+    color: darken($fill-red, 20%);
   }
 
   .page-message__delete-icon {
@@ -77,6 +84,10 @@
       background-color: $fill-green;
       border-radius: 50%;
     }
+
+    .page-message__action:hover {
+      color: darken($fill-green, 20%);
+    }
   }
 
   .page-message__delete-icon {
@@ -86,8 +97,4 @@
   & .page-message__delete:hover .page-message__delete-icon {
     fill: $fill-green;
   }
-}
-
-.page-message__action:hover {
-  color: $text-blue;  
 }

--- a/messaging.html
+++ b/messaging.html
@@ -8,7 +8,7 @@ title: Messaging
   <a name="success-and-error-messages"></a>
   <h2 class="bold xs-mb2">Success and Error Messages</h2>
 
-  <p class="xs-mb4">Use the following code snippets to add Success and Error messaging to your page. The <span class="nowrap">.<code class="js-highlight">page-message__action</code></span> link is optional.</p>
+  <p class="xs-mb4">Use the following code snippets to add Success and Error messaging to your page. The <span class="nowrap">.<code class="js-highlight">page-message__action</code></span> link is optional. If users can dismiss the message, include the optional <span class="nowrap">.<code class="js-highlight">page-message__delete</code></span> markup, with inline <span class="nowrap"><code class="js-highlight">svg</code></span>.</p>
 
   <div class="page-message page-message--success xs-mb2">
     <div class="page-message__text">Your settings have been saved.
@@ -16,84 +16,47 @@ title: Messaging
     </div>
   </div>
 
-  <div class="page-message page-message--error xs-mb4">
+  <div class="page-message page-message--error xs-mb2">
     <div class="page-message__text">Oh no, something went wrong. 
       <a class="page-message__action" href="#">Fix this error.</a>
     </div>
   </div>
 
-  <div class="xs-mb4">
-    {% highlight html %}<div class="page-message page-message--success">
-      <span class="page-message__delete">
-        <svg viewBox="0 0 512 512" class="page-message__delete-icon" xmlns="http://www.w3.org/2000/svg">
-          <path d="M133.874 227.048L19.198 108.276C-6.4 82.68-6.4 44.796 19.198 19.198c25.597-25.597 63.48-25.597 89.078 0l114.676 114.676L337.628 19.198c25.597-25.597 68.09-25.597 93.174 0 25.597 25.597 25.597 68.09 0 93.174L316.126 227.048l114.676 114.676c25.597 25.597 25.597 63.48 0 89.078-25.597 25.597-63.48 25.597-89.078 0L227.048 316.126 112.372 430.802c-25.597 25.597-68.09 25.597-93.174 0-25.597-25.597-25.597-68.09 0-93.174l114.676-110.58z"/>
-        </svg>
-      </span>
-      <div class="page-message__text">Your settings have been saved.
-        <a class="page-message__action" href="#">View your settings.</a>
-      </div>
-    </div>{% endhighlight %} 
-  </div>
-
-  <div class="xs-mb4">
-    {% highlight html %}<div class="page-message page-message--error">
-      <div class="page-message__text">Oh no, something went wrong.
-        <a class="page-message__action" href="#">Fix this error.</a>
-      </div>
-    </div>{% endhighlight %} 
-  </div>
-
-</section>
-
-<section class="xs-mb6">
-  
-  <a name="success-and-error-messages"></a>
-  <h2 class="bold xs-mb2">Dismissible Messages</h2>
-
-  <p class="xs-mb4">If users can dismiss the message, include the optional <span class="nowrap">.<code class="js-highlight">page-message__delete</code></span> markup, with inline <span class="nowrap"><code class="js-highlight">svg</code></span>.</p>
-
-  <div class="page-message page-message--success xs-mb2">
+  <div class="page-message page-message--success xs-mb4">
+    <div class="page-message__text">This message is dismissible.</div>
     <span class="page-message__delete">
       <svg viewBox="0 0 512 512" class="page-message__delete-icon" xmlns="http://www.w3.org/2000/svg">
         <path d="M133.874 227.048L19.198 108.276C-6.4 82.68-6.4 44.796 19.198 19.198c25.597-25.597 63.48-25.597 89.078 0l114.676 114.676L337.628 19.198c25.597-25.597 68.09-25.597 93.174 0 25.597 25.597 25.597 68.09 0 93.174L316.126 227.048l114.676 114.676c25.597 25.597 25.597 63.48 0 89.078-25.597 25.597-63.48 25.597-89.078 0L227.048 316.126 112.372 430.802c-25.597 25.597-68.09 25.597-93.174 0-25.597-25.597-25.597-68.09 0-93.174l114.676-110.58z"/>
       </svg>
     </span>
-    <div class="page-message__text">Your settings have been saved.</div>
   </div>
 
-  <div class="page-message page-message--error xs-mb4">
+<div class="xs-mb2">
+{% highlight html %}<div class="page-message page-message--success">
+  <div class="page-message__text">Your settings have been saved.
+    <a class="page-message__action" href="#">View your settings.</a>
+  </div>
+</div>{% endhighlight %} 
+</div>
+
+<div class="xs-mb2">
+{% highlight html %}<div class="page-message page-message--error">
+  <div class="page-message__text">Oh no, something went wrong.
+    <a class="page-message__action" href="#">Fix this error.</a>
+  </div>
+</div>{% endhighlight %} 
+</div>
+
+<div class="xs-mb2">
+{% highlight html %}<div class="page-message page-message--success">
+  <div class="page-message__text">This message is dismissible.</div>
     <span class="page-message__delete">
       <svg viewBox="0 0 512 512" class="page-message__delete-icon" xmlns="http://www.w3.org/2000/svg">
         <path d="M133.874 227.048L19.198 108.276C-6.4 82.68-6.4 44.796 19.198 19.198c25.597-25.597 63.48-25.597 89.078 0l114.676 114.676L337.628 19.198c25.597-25.597 68.09-25.597 93.174 0 25.597 25.597 25.597 68.09 0 93.174L316.126 227.048l114.676 114.676c25.597 25.597 25.597 63.48 0 89.078-25.597 25.597-63.48 25.597-89.078 0L227.048 316.126 112.372 430.802c-25.597 25.597-68.09 25.597-93.174 0-25.597-25.597-25.597-68.09 0-93.174l114.676-110.58z"/>
       </svg>
     </span>
-    <div class="page-message__text">Oh no, something went wrong.</div>
   </div>
-
-  <div class="xs-mb4">
-    {% highlight html %}<div class="page-message page-message--success">
-      <span class="page-message__delete">
-        <svg viewBox="0 0 512 512" class="page-message__delete-icon" xmlns="http://www.w3.org/2000/svg">
-          <path d="M133.874 227.048L19.198 108.276C-6.4 82.68-6.4 44.796 19.198 19.198c25.597-25.597 63.48-25.597 89.078 0l114.676 114.676L337.628 19.198c25.597-25.597 68.09-25.597 93.174 0 25.597 25.597 25.597 68.09 0 93.174L316.126 227.048l114.676 114.676c25.597 25.597 25.597 63.48 0 89.078-25.597 25.597-63.48 25.597-89.078 0L227.048 316.126 112.372 430.802c-25.597 25.597-68.09 25.597-93.174 0-25.597-25.597-25.597-68.09 0-93.174l114.676-110.58z"/>
-        </svg>
-      </span>
-      <div class="page-message__text">Your settings have been saved.
-        <a class="page-message__action" href="#">View your settings.</a>
-      </div>
-    </div>{% endhighlight %} 
-  </div>
-
-  <div class="xs-mb4">
-    {% highlight html %}<div class="page-message page-message--error">
-    <span class="page-message__delete">
-      <svg viewBox="0 0 512 512" class="page-message__delete-icon" xmlns="http://www.w3.org/2000/svg">
-        <path d="M133.874 227.048L19.198 108.276C-6.4 82.68-6.4 44.796 19.198 19.198c25.597-25.597 63.48-25.597 89.078 0l114.676 114.676L337.628 19.198c25.597-25.597 68.09-25.597 93.174 0 25.597 25.597 25.597 68.09 0 93.174L316.126 227.048l114.676 114.676c25.597 25.597 25.597 63.48 0 89.078-25.597 25.597-63.48 25.597-89.078 0L227.048 316.126 112.372 430.802c-25.597 25.597-68.09 25.597-93.174 0-25.597-25.597-25.597-68.09 0-93.174l114.676-110.58z"/>
-      </svg>
-    </span>
-      <div class="page-message__text">Oh no, something went wrong.
-        <a class="page-message__action" href="#">Fix this error.</a>
-      </div>
-    </div>{% endhighlight %} 
-  </div>
+</div>{% endhighlight %} 
+</div>
 
 </section>


### PR DESCRIPTION
Here is my first pass. Preview: 

![preview](https://cloud.githubusercontent.com/assets/875366/12341625/fb48bf78-baf0-11e5-9a46-76265b5802e6.png)
1. I based this markup pattern and styling on @emilybrick’s tag branch, which is currently unfinished. So we should keep in sync!
2. I split “Dismissible” messages into its own section, because I wanted to underscore that it is _optional_. If people just copy/paste the code snippet, they might get that idea, if they don’t read closely. Is that overkill? Also, let me know if you have better ideas around language for style and clarity.
3. Curious what y’all think about negative positioning of the [x]. I wanted to allow for a more generous click/tap target, without changing too much of the existing markup and styling. Is this inelegant?

```
.page-message__delete {
  …
  padding: .2rem .4rem;
  margin: -.2rem -.4rem;
  …
}
```
1. Do we like this link hover color in this context? Seems abrupt — we could do opacity instead, similar to the X?

![do-we-like-this-hover-color](https://cloud.githubusercontent.com/assets/875366/12341569/a1f64210-baf0-11e5-82f9-0cad5b05ac6c.png)

Thanks!
