### PR TITLE
SOLID-302: Lessened bordered table padding

### DIFF
--- a/_lib/solid-utilities/_tables.scss
+++ b/_lib/solid-utilities/_tables.scss
@@ -15,7 +15,7 @@
 
 .table-border td, 
 .table-border th {
-  padding: $space-2 !important;
+  padding: .75rem !important;
 }
 
 


### PR DESCRIPTION
From 1rem to .75rem.

![screen shot 2016-02-18 at 3 04 44 pm](https://cloud.githubusercontent.com/assets/875366/13156544/fe7eb870-d650-11e5-8134-81b594390cc4.png)
