### PR TITLE
Solid 283 border color error status

### DIFF
--- a/_lib/solid-utilities/_forms.scss
+++ b/_lib/solid-utilities/_forms.scss
@@ -22,10 +22,12 @@
   }
 }
 
-.text-input,
+.text-input, 
+.text-input--small,
 .textarea,
+.textarea--small,
 .select,
-.date-input {
+.select--small {
   font-family: inherit        !important;
   background: $fill-white     !important;
   font-size: $text-4          !important;
@@ -52,8 +54,7 @@ select::-ms-expand,
 }
 
 .select--small,
-.text-input--small,
-.date-input--small {
+.text-input--small {
   font-size: $text-5          !important;
   line-height: $line-height-5 !important;
   padding: 0.3125rem .625rem  !important;
@@ -167,7 +168,11 @@ select::-ms-expand,
   }
 
   .text-input,
-  .select {
+  .text-input--small,
+  .textarea,
+  .textarea--small,
+  .select,
+  .select--small {
     border-color: $fill-orange !important; 
   }
 }
@@ -195,7 +200,11 @@ select::-ms-expand,
   }
 
   .text-input,
-  .select {
+  .text-input--small,
+  .textarea,
+  .textarea--small,
+  .select,
+  .select--small {
     border-color: $fill-green !important; 
   }
 }
@@ -207,7 +216,11 @@ select::-ms-expand,
   }
 
   .text-input,
-  .select {
+  .text-input--small,
+  .textarea,
+  .textarea--small,
+  .select,
+  .select--small {
     border-color: $fill-red !important;
   }
 }

--- a/release-notes.html
+++ b/release-notes.html
@@ -15,7 +15,7 @@ title: Release Notes
       <div class="col xs-col-10 lg-col-11">
         <h4 class="bold xs-mb1 text-grey--lightest">Under Development</h4>
          <ul>
-          <li class="xs-mb1"></li>
+          <li class="xs-mb1">Fixed bug to extend input error state borders to textareas and small inputs.</li>
         </ul>
 
       </div>


### PR DESCRIPTION
This ended up being more than just adding an error state border to textareas - on further inspection the same was missing from the modified --small inputs and textareas, as well as date-input and select.
- add error/warning/success state styles to _all_ input types and modified input types
- add base solid form styles to _all_ input types to fix another bug which was causing the input styles to revert to browser defaults when an error status was added. Please let me know if this approach is incorrect or excessive/redundant. See image for behavior.

https://monosnap.com/file/NYqtm75lJiZPt0FACPSH4BHUytbezv.png
