### PR TITLE
updated to stable version 1.4.5

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,9 +26,9 @@ title: WTF is Solid?
 
   <h3 class="bold xs-mb2">Download</h3>
   <p>
-    <a href="dist/solid.1.4.4.zip" download class="xs-mr1 button button--secondary">Source Files</a>
-    <a href="dist/solid.1.4.4.css" download class="xs-mr1 button button--secondary">Compiled CSS</a>
-    <a href="dist/solid.1.4.4.min.css" download class="xs-mr1 button button--secondary">Compiled CSS (minified)</a>
+    <a href="dist/solid.1.4.5.zip" download class="xs-mr1 button button--secondary">Source Files</a>
+    <a href="dist/solid.1.4.5.css" download class="xs-mr1 button button--secondary">Compiled CSS</a>
+    <a href="dist/solid.1.4.5.min.css" download class="xs-mr1 button button--secondary">Compiled CSS (minified)</a>
   </p>
 
 </section>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bf-solid",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "description": "Solid CSS Styling",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/release-notes.html
+++ b/release-notes.html
@@ -23,12 +23,27 @@ title: Release Notes
 
    <div class="release clearfix xs-mb2 xs-pb1 xs-border-bottom--lighter">
       <div class="col xs-col-2 lg-col-1 text-gray--lightest">
+        1.4.5
+      </div>
+
+      <div class="col xs-col-10 lg-col-11">
+        <h4 class="bold xs-mb1 text-grey--lightest">X Gonna Give it To Ya: Close Button in Messaging STABLE</h4>
+         <ul>
+          <li class="xs-mb1">Stable version of 1.4.4</li>
+        </ul>
+
+      </div>
+    </div>
+
+   <div class="release clearfix xs-mb2 xs-pb1 xs-border-bottom--lighter">
+      <div class="col xs-col-2 lg-col-1 text-gray--lightest">
         1.4.4
       </div>
 
       <div class="col xs-col-10 lg-col-11">
         <h4 class="bold xs-mb1 text-grey--lightest">X Gonna Give it To Ya: Close Button in Messaging</h4>
          <ul>
+          <li class="xs-mb1"><span class="text-red bold">DEPRECATED</span> Package did not publish correctly, use version 1.4.5 instead</li>
           <li class="xs-mb1">Added a close option to Messaging component.</li>
         </ul>
 


### PR DESCRIPTION
Solid 1.4.4 on NPM mysteriously didn't include the entire _lib folder
this is the worst thing that could happen!
even worse it's not clear _why_ it happened
we're going to add an extra debug step do our deploy process to make sure this doesn't happen again, it's troubling to say the least

fixing everything in a new version (which is good practice)
