### PR TITLE
added h1 test file to compare between new size and old

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -1,7 +1,7 @@
 <!-- Desktop Nav -->
 
 <nav class="xs-col-12 sm-col-3 lg-col-2 sm-fixed xs-t0 sm-b0 xs-l0 xs-overflow-auto sm-py3 sm-pb6 xs-border-bottom sm-border-bottom-none sm-border-right fill-white solid-nav">
-  
+
   <h1 class="xs-relative xs-py3 sm-py0 sm-mb4 solid-header">
     <div class="sm-block solid-header--desktop-logo">
       <a href="/" class="solid-logo">Solid</a>
@@ -45,7 +45,7 @@
         {% endif %}
 
       </li>
-      
+
       <li class="solid-nav__group {% if page.title == 'Colors' %}active{% endif %}" >
 
         <a class="xs-block xs-px2 xs-py2 sm-py1 bold solid-nav__item" href="/colors.html">Colors</a>
@@ -225,8 +225,12 @@
         <a class="xs-block xs-px2 xs-py2 sm-py1 bold solid-nav__item" href="tags.html">Tags</a>
       </li>
 
+      <li class="solid-nav__group {% if page.title == 'H1 Test' %}active{% endif %}">
+        <a class="xs-block xs-px2 xs-py2 sm-py1 bold solid-nav__item" href="h1-test.html">H1 Test</a>
+      </li>
+
     </ol>
-    
+
   </div>
 
 </nav>

--- a/_lib/solid-helpers/_variables.scss
+++ b/_lib/solid-helpers/_variables.scss
@@ -88,7 +88,8 @@ $text-instagram: #517fa4;
 
 $base-font-size: 16px;
 
-$text-1: 2.25rem;   // 36px
+$text-1: 1.75rem;   // 28px
+$text-1-old: 2.25rem; // 36px
 $text-2: 1.375rem;  // 22px
 $text-3: 1.125rem;  // 18px
 $text-4: 1rem;      // 16px

--- a/_lib/solid-utilities/_typography.scss
+++ b/_lib/solid-utilities/_typography.scss
@@ -5,32 +5,37 @@
 // Text Size
 // -------------------------
 
-.text-1 { 
+.text-1 {
   font-size:   $text-1       !important;
   line-height: $line-height-1 !important;
 }
 
-.text-2 { 
+.text-1-old {
+  font-size:   $text-1-old !important;
+  line-height: $line-height-1 !important;
+}
+
+.text-2 {
   font-size:   $text-2       !important;
   line-height: $line-height-2 !important;
 }
 
-.text-3 { 
+.text-3 {
   font-size:   $text-3       !important;
   line-height: $line-height-3 !important;
 }
 
-.text-4 { 
+.text-4 {
   font-size:   $text-4       !important;
   line-height: $line-height-4 !important;
 }
 
-.text-5 { 
+.text-5 {
   font-size:   $text-5       !important;
   line-height: $line-height-5 !important;
 }
 
-.text-6 { 
+.text-6 {
   font-size:   $text-6       !important;
   line-height: $line-height-6 !important;
 }
@@ -87,7 +92,7 @@
 
 // List styles
 // -------------------------
-// Unstyled keeps list items block level, 
+// Unstyled keeps list items block level,
 // just removes default browser padding and list-style
 
 .list-unstyled {
@@ -161,7 +166,7 @@
 
 // Slab specific fixes
 // -------------------------
-// Slab should never be an h6 or .type-6, 
+// Slab should never be an h6 or .type-6,
 // these classes disallow that from happening
 // (type will default to Sans)
 

--- a/h1-test.html
+++ b/h1-test.html
@@ -1,0 +1,104 @@
+---
+layout: default
+title: H1 Test
+---
+
+<section class="xs-mb3 xs-pr6">
+
+	<div class="xs-my3">
+		<h1 class="text-1-old">SeaWorld Bans Employees From Posing As Animal Rights Activists</h1>
+		<p class="text-gray--lightest">A half hour ago, "This activity was undertaken in connection with efforts to maintain the safety and security of employees, customers and animals in the face of credible threats", the company’s CEO said.</p>
+	</div>
+
+	<div class="xs-my3">
+		<h2>David Duke Urges His Supporters To Volunteer And Vote For Trump</h2>
+		<p class="text-gray--lightest">"Voting against Donald Trump at this point is really treason to your heritage."</p>
+	</div>
+
+	<div class="xs-my3">
+		<h2>These College Students Allegedly Stabbed A 20-Year-Old And Posted About It On Snapchat</h2>
+		<p class="text-gray--lightest">The suspects and the victim are all reportedly members of the same fraternity.</p>
+	</div>
+
+	<div class="xs-my3">
+		<h2>FBI Director Says Battle With Apple Could Set Legal Precedent</h2>
+		<p class="text-gray--lightest">The FBI wants Apple to help it unlock the iPhone beloning to one of the shooters in the San Bernardino terrorist attack.</p>
+	</div>
+
+	<div class="xs-my3">
+		<h3>These College Students Allegedly Stabbed A 20-Year-Old And Posted About It On Snapchat</h3>
+		<p class="text-gray--lightest">The suspects and the victim are all reportedly members of the same fraternity.</p>
+	</div>
+
+	<div class="xs-my3">
+		<h3>FBI Director Says Battle With Apple Could Set Legal Precedent</h3>
+		<p class="text-gray--lightest">The FBI wants Apple to help it unlock the iPhone beloning to one of the shooters in the San Bernardino terrorist attack.</p>
+	</div>
+
+	<div class="xs-my3">
+		<h4>These College Students Allegedly Stabbed A 20-Year-Old And Posted About It On Snapchat</h4>
+		<p class="text-gray--lightest">The suspects and the victim are all reportedly members of the same fraternity.</p>
+	</div>
+
+	<div class="xs-my3">
+		<h4>FBI Director Says Battle With Apple Could Set Legal Precedent</h4>
+		<p class="text-gray--lightest">The FBI wants Apple to help it unlock the iPhone beloning to one of the shooters in the San Bernardino terrorist attack.</p>
+	</div>
+
+	<div class="xs-my3">
+		<h5 class="xs-my2">8 Killed, States Of Emergency Declared As Tornadoes Sweep Southeast</h5>
+		<h5 class="xs-my2">How Turkey Became The Top Censor Of Twitter Accounts Worldwide</h5>
+		<h5 class="xs-my2">Amazon Pulls Hoverboards From Site After New Safety Warning</h5>
+	</div>
+
+</section>
+
+<section class="xs-border-top--lighter xs-mb3 xs-pr6">
+
+	<div class="xs-my3">
+		<h1 class="text-1--test">SeaWorld Bans Employees From Posing As Animal Rights Activists</h1>
+		<p class="text-gray--lightest">A half hour ago, "This activity was undertaken in connection with efforts to maintain the safety and security of employees, customers and animals in the face of credible threats", the company’s CEO said.</p>
+	</div>
+
+	<div class="xs-my3">
+		<h2>David Duke Urges His Supporters To Volunteer And Vote For Trump</h2>
+		<p class="text-gray--lightest">"Voting against Donald Trump at this point is really treason to your heritage."</p>
+	</div>
+
+	<div class="xs-my3">
+		<h2>These College Students Allegedly Stabbed A 20-Year-Old And Posted About It On Snapchat</h2>
+		<p class="text-gray--lightest">The suspects and the victim are all reportedly members of the same fraternity.</p>
+	</div>
+
+	<div class="xs-my3">
+		<h2>FBI Director Says Battle With Apple Could Set Legal Precedent</h2>
+		<p class="text-gray--lightest">The FBI wants Apple to help it unlock the iPhone beloning to one of the shooters in the San Bernardino terrorist attack.</p>
+	</div>
+
+	<div class="xs-my3">
+		<h3>These College Students Allegedly Stabbed A 20-Year-Old And Posted About It On Snapchat</h3>
+		<p class="text-gray--lightest">The suspects and the victim are all reportedly members of the same fraternity.</p>
+	</div>
+
+	<div class="xs-my3">
+		<h3>FBI Director Says Battle With Apple Could Set Legal Precedent</h3>
+		<p class="text-gray--lightest">The FBI wants Apple to help it unlock the iPhone beloning to one of the shooters in the San Bernardino terrorist attack.</p>
+	</div>
+
+	<div class="xs-my3">
+		<h4>These College Students Allegedly Stabbed A 20-Year-Old And Posted About It On Snapchat</h4>
+		<p class="text-gray--lightest">The suspects and the victim are all reportedly members of the same fraternity.</p>
+	</div>
+
+	<div class="xs-my3">
+		<h4>FBI Director Says Battle With Apple Could Set Legal Precedent</h4>
+		<p class="text-gray--lightest">The FBI wants Apple to help it unlock the iPhone beloning to one of the shooters in the San Bernardino terrorist attack.</p>
+	</div>
+
+	<div class="xs-my3">
+		<h5 class="xs-my2">8 Killed, States Of Emergency Declared As Tornadoes Sweep Southeast</h5>
+		<h5 class="xs-my2">How Turkey Became The Top Censor Of Twitter Accounts Worldwide</h5>
+		<h5 class="xs-my2">Amazon Pulls Hoverboards From Site After New Safety Warning</h5>
+	</div>
+
+</section>


### PR DESCRIPTION
Just starting this out. 

/h1-test has a few examples of story blocks with varied header sizes for comparison

**the top section's h1** = larger (current) size (2.25rem)
**the bottom section's h1** = proposed size (1.75rem)

/typography shows the new proposed h1 size.

In general:
the smaller h1 feels much, much more relatively sized to the others than it did before. I feel pretty strongly that we should go with something closer to this size, and if we need larger type for b-page headlines, etc we can add a custom class.

Q's: 
is this size big enough for modal headers? If not, are custom classes ok in that scenario
