### PR TITLE
fix titles, punctuation, and deprecation formatting in release notes

### DIFF
--- a/release-notes.html
+++ b/release-notes.html
@@ -16,7 +16,7 @@ title: Release Notes
         <ul>
           <li class="xs-mb1"><span class="text-orange bold">Deprecated:</span> All lighter versions of borders have changed from <span class="nowrap">.<code class="js-highlight">xs-border--lighter</code></span> to <span class="nowrap">.<code class="js-highlight">xs-border-lighter</code></span>. Double-dashed class names will be removed in 2.0.</li>
           <li class="xs-mb1"><span class="text-red bold">Potential Breaking Change:</span> Reduced the h1 size to 1.75rem (28px). Previously h1 was 2.25rem (36px).</li>
-          <li class="xs-mb1"><span class="text-red bold">Deprecated:</span> All fill, link and text color classes and variables now use single dash modifider format instead of the double dash format. Any classes that were previously using the double dash format will be removed in Solid 2.0.</li>
+          <li class="xs-mb1"><span class="text-orange bold">Deprecated:</span> All fill, link and text color classes and variables now use single dash modifider format instead of the double dash format. Any classes that were previously using the double dash format will be removed in Solid 2.0.</li>
 
         </ul>
       </div>


### PR DESCRIPTION
Standardized release notes:
- Standardized deprecation formatting to orange, breaking changes to red
- Cleaned up and standardized punctuation, titles, capitalization, and some spelling and syntax
