### PR TITLE
updated _normalize to 4.0, removed comments from compilation

### DIFF
--- a/_lib/solid-base/_normalize.scss
+++ b/_lib/solid-base/_normalize.scss
@@ -1,163 +1,178 @@
-/*! normalize.css v3.0.3 | MIT License | github.com/necolas/normalize.css */
-
-/**
- * 1. Set default font family to sans-serif.
- * 2. Prevent iOS and IE text size adjust after device orientation change,
- *    without disabling user zoom.
- */
+// /*! normalize.css v4.0.0 | MIT License | github.com/necolas/normalize.css */
+//
+// /**
+//  * 1. Change the default font family in all browsers (opinionated).
+//  * 2. Prevent adjustments of font size after orientation changes in IE and iOS.
+//  */
 
 html {
-  font-family: sans-serif; /* 1 */
-  -ms-text-size-adjust: 100%; /* 2 */
-  -webkit-text-size-adjust: 100%; /* 2 */
+  font-family: sans-serif; // /* 1 */
+  -ms-text-size-adjust: 100%; // /* 2 */
+  -webkit-text-size-adjust: 100%; // /* 2 */
 }
 
-/**
- * Remove default margin.
- */
+// /**
+//  * Remove the margin in all browsers (opinionated).
+//  */
 
 body {
   margin: 0;
 }
 
-/* HTML5 display definitions
-   ========================================================================== */
-
-/**
- * Correct `block` display not defined for any HTML5 element in IE 8/9.
- * Correct `block` display not defined for `details` or `summary` in IE 10/11
- * and Firefox.
- * Correct `block` display not defined for `main` in IE 11.
- */
+// /* HTML5 display definitions
+//    ========================================================================== */
+//
+// /**
+//  * Add the correct display in IE 9-.
+//  * 1. Add the correct display in Edge, IE, and Firefox.
+//  * 2. Add the correct display in IE.
+//  */
 
 article,
 aside,
-details,
+details, // /* 1 */
 figcaption,
 figure,
 footer,
 header,
-hgroup,
-main,
+main, // /* 2 */
 menu,
 nav,
 section,
-summary {
+summary { ///* 1 */
   display: block;
 }
 
-/**
- * 1. Correct `inline-block` display not defined in IE 8/9.
- * 2. Normalize vertical alignment of `progress` in Chrome, Firefox, and Opera.
- */
+// /**
+//  * Add the correct display in IE 9-.
+//  */
 
 audio,
 canvas,
 progress,
 video {
-  display: inline-block; /* 1 */
-  vertical-align: baseline; /* 2 */
+  display: inline-block;
 }
 
-/**
- * Prevent modern browsers from displaying `audio` without controls.
- * Remove excess height in iOS 5 devices.
- */
+// /**
+//  * Add the correct display in iOS 4-7.
+//  */
 
 audio:not([controls]) {
   display: none;
   height: 0;
 }
 
-/**
- * Address `[hidden]` styling not present in IE 8/9/10.
- * Hide the `template` element in IE 8/9/10/11, Safari, and Firefox < 22.
- */
+// /**
+//  * Add the correct vertical alignment in Chrome, Firefox, and Opera.
+//  */
 
-[hidden],
-template {
+progress {
+  vertical-align: baseline;
+}
+
+// /**
+//  * Add the correct display in IE 10-.
+//  * 1. Add the correct display in IE.
+//  */
+
+template, /* 1 */
+[hidden] {
   display: none;
 }
 
-/* Links
-   ========================================================================== */
-
-/**
- * Remove the gray background color from active links in IE 10.
- */
+// /* Links
+//    ========================================================================== */
+//
+// /**
+//  * Remove the gray background on active links in IE 10.
+//  */
 
 a {
   background-color: transparent;
 }
 
-/**
- * Improve readability of focused elements when they are also in an
- * active/hover state.
- */
+// /**
+//  * Remove the outline on focused links when they are also active or hovered
+//  * in all browsers (opinionated).
+//  */
 
 a:active,
 a:hover {
-  outline: 0;
+  outline-width: 0;
 }
 
-/* Text-level semantics
-   ========================================================================== */
-
-/**
- * Address styling not present in IE 8/9/10/11, Safari, and Chrome.
- */
+// /* Text-level semantics
+//    ========================================================================== */
+//
+// /**
+//  * 1. Remove the bottom border in Firefox 39-.
+//  * 2. Add the correct text decoration in Chrome, Edge, IE, Opera, and Safari.
+//  */
 
 abbr[title] {
-  border-bottom: 1px dotted;
+  border-bottom: none; // /* 1 */
+  text-decoration: underline; // /* 2 */
+  text-decoration: underline dotted; // /* 2 */
 }
 
-/**
- * Address style set to `bolder` in Firefox 4+, Safari, and Chrome.
- */
+// /**
+//  * Prevent the duplicate application of `bolder` by the next rule in Safari 6.
+//  */
 
 b,
 strong {
-  font-weight: bold;
+  font-weight: inherit;
 }
 
-/**
- * Address styling not present in Safari and Chrome.
- */
+// /**
+//  * Add the correct font weight in Chrome, Edge, and Safari.
+//  */
+
+b,
+strong {
+  font-weight: bolder;
+}
+
+// /**
+//  * Add the correct font style in Android 4.3-.
+//  */
 
 dfn {
   font-style: italic;
 }
 
-/**
- * Address variable `h1` font-size and margin within `section` and `article`
- * contexts in Firefox 4+, Safari, and Chrome.
- */
+// /**
+//  * Correct the font size and margin on `h1` elements within `section` and
+//  * `article` contexts in Chrome, Firefox, and Safari.
+//  */
 
 h1 {
   font-size: 2em;
   margin: 0.67em 0;
 }
 
-/**
- * Address styling not present in IE 8/9.
- */
+// /**
+//  * Add the correct background and color in IE 9-.
+//  */
 
 mark {
-  background: #ff0;
+  background-color: #ff0;
   color: #000;
 }
 
-/**
- * Address inconsistent and variable font size in all browsers.
- */
+// /**
+//  * Add the correct font size in all browsers.
+//  */
 
 small {
   font-size: 80%;
 }
 
-/**
- * Prevent `sub` and `sup` affecting `line-height` in all browsers.
- */
+// /**
+//  * Prevent `sub` and `sup` elements from affecting the line height in
+//  * all browsers.
+//  */
 
 sub,
 sup {
@@ -167,146 +182,159 @@ sup {
   vertical-align: baseline;
 }
 
-sup {
-  top: -0.5em;
-}
-
 sub {
   bottom: -0.25em;
 }
 
-/* Embedded content
-   ========================================================================== */
-
-/**
- * Remove border when inside `a` element in IE 8/9/10.
- */
-
-img {
-  border: 0;
+sup {
+  top: -0.5em;
 }
 
-/**
- * Correct overflow not hidden in IE 9/10/11.
- */
+// /* Embedded content
+//    ========================================================================== */
+//
+// /**
+//  * Remove the border on images inside links in IE 10-.
+//  */
+
+img {
+  border-style: none;
+}
+
+// /**
+//  * Hide the overflow in IE.
+//  */
 
 svg:not(:root) {
   overflow: hidden;
 }
 
-/* Grouping content
-   ========================================================================== */
-
-/**
- * Address margin not present in IE 8/9 and Safari.
- */
-
-figure {
-  margin: 1em 40px;
-}
-
-/**
- * Address differences between Firefox and other browsers.
- */
-
-hr {
-  box-sizing: content-box;
-  height: 0;
-}
-
-/**
- * Contain overflow in all browsers.
- */
-
-pre {
-  overflow: auto;
-}
-
-/**
- * Address odd `em`-unit font size rendering in all browsers.
- */
+// /* Grouping content
+//    ========================================================================== */
+//
+// /**
+//  * 1. Correct the inheritance and scaling of font size in all browsers.
+//  * 2. Correct the odd `em` font sizing in all browsers.
+//  */
 
 code,
 kbd,
 pre,
 samp {
-  font-family: monospace, monospace;
-  font-size: 1em;
+  font-family: monospace, monospace; // /* 1 */
+  font-size: 1em; // /* 2 */
 }
 
-/* Forms
-   ========================================================================== */
+// /**
+//  * Add the correct margin in IE 8.
+//  */
 
-/**
- * Known limitation: by default, Chrome and Safari on OS X allow very limited
- * styling of `select`, unless a `border` property is set.
- */
+figure {
+  margin: 1em 40px;
+}
 
-/**
- * 1. Correct color not being inherited.
- *    Known issue: affects color of disabled elements.
- * 2. Correct font properties not being inherited.
- * 3. Address margins set differently in Firefox 4+, Safari, and Chrome.
- */
+// /**
+//  * 1. Add the correct box sizing in Firefox.
+//  * 2. Show the overflow in Edge and IE.
+//  */
+
+hr {
+  box-sizing: content-box; // /* 1 */
+  height: 0; // /* 1 */
+  overflow: visible; // /* 2 */
+}
+
+// /* Forms
+//    ========================================================================== */
+//
+// /**
+//  * Change font properties to `inherit` in all browsers (opinionated).
+//  */
 
 button,
 input,
-optgroup,
 select,
 textarea {
-  color: inherit; /* 1 */
-  font: inherit; /* 2 */
-  margin: 0; /* 3 */
+  font: inherit;
 }
 
-/**
- * Address `overflow` set to `hidden` in IE 8/9/10/11.
- */
+// /**
+//  * Restore the font weight unset by the previous rule.
+//  */
 
-button {
+optgroup {
+  font-weight: bold;
+}
+
+// /**
+//  * Show the overflow in IE.
+//  * 1. Show the overflow in Edge.
+//  * 2. Show the overflow in Edge, Firefox, and IE.
+//  */
+
+button,
+input, // /* 1 */
+select { // /* 2 */
   overflow: visible;
 }
 
-/**
- * Address inconsistent `text-transform` inheritance for `button` and `select`.
- * All other form control elements do not inherit `text-transform` values.
- * Correct `button` style inheritance in Firefox, IE 8/9/10/11, and Opera.
- * Correct `select` style inheritance in Firefox.
- */
+// /**
+//  * Remove the margin in Safari.
+//  * 1. Remove the margin in Firefox and Safari.
+//  */
 
 button,
-select {
+input,
+select,
+textarea { // /* 1 */
+  margin: 0;
+}
+
+// /**
+//  * Remove the inheritence of text transform in Edge, Firefox, and IE.
+//  * 1. Remove the inheritence of text transform in Firefox.
+//  */
+
+button,
+select { // /* 1 */
   text-transform: none;
 }
 
-/**
- * 1. Avoid the WebKit bug in Android 4.0.* where (2) destroys native `audio`
- *    and `video` controls.
- * 2. Correct inability to style clickable `input` types in iOS.
- * 3. Improve usability and consistency of cursor style between image-type
- *    `input` and others.
- */
+// /**
+//  * Change the cursor in all browsers (opinionated).
+//  */
 
 button,
-html input[type="button"], /* 1 */
-input[type="reset"],
-input[type="submit"] {
-  -webkit-appearance: button; /* 2 */
-  cursor: pointer; /* 3 */
+[type="button"],
+[type="reset"],
+[type="submit"] {
+  cursor: pointer;
 }
 
-/**
- * Re-set default cursor for disabled elements.
- */
+// /**
+//  * Restore the default cursor to disabled elements unset by the previous rule.
+//  */
 
-button[disabled],
-html input[disabled] {
+[disabled] {
   cursor: default;
 }
 
-/**
- * Remove inner padding and border in Firefox 4+.
- */
+// /**
+//  * 1. Prevent a WebKit bug where (2) destroys native `audio` and `video`
+//  *    controls in Android 4.
+//  * 2. Correct the inability to style clickable types in iOS.
+//  */
+
+button,
+html [type="button"], // /* 1 */
+[type="reset"],
+[type="submit"] {
+  -webkit-appearance: button; // /* 2 */
+}
+
+// /**
+//  * Remove the inner border and padding in Firefox.
+//  */
 
 button::-moz-focus-inner,
 input::-moz-focus-inner {
@@ -314,64 +342,18 @@ input::-moz-focus-inner {
   padding: 0;
 }
 
-/**
- * Address Firefox 4+ setting `line-height` on `input` using `!important` in
- * the UA stylesheet.
- */
+// /**
+//  * Restore the focus styles unset by the previous rule.
+//  */
 
-input {
-  line-height: normal;
+button:-moz-focusring,
+input:-moz-focusring {
+  outline: 1px dotted ButtonText;
 }
 
-/**
- * It's recommended that you don't attempt to style these elements.
- * Firefox's implementation doesn't respect box-sizing, padding, or width.
- *
- * 1. Address box sizing set to `content-box` in IE 8/9/10.
- * 2. Remove excess padding in IE 8/9/10.
- */
-
-input[type="checkbox"],
-input[type="radio"] {
-  box-sizing: border-box; /* 1 */
-  padding: 0; /* 2 */
-}
-
-/**
- * Fix the cursor style for Chrome's increment/decrement buttons. For certain
- * `font-size` values of the `input`, it causes the cursor style of the
- * decrement button to change from `default` to `text`.
- */
-
-input[type="number"]::-webkit-inner-spin-button,
-input[type="number"]::-webkit-outer-spin-button {
-  height: auto;
-}
-
-/**
- * 1. Address `appearance` set to `searchfield` in Safari and Chrome.
- * 2. Address `box-sizing` set to `border-box` in Safari and Chrome.
- */
-
-input[type="search"] {
-  -webkit-appearance: textfield; /* 1 */
-  box-sizing: content-box; /* 2 */
-}
-
-/**
- * Remove inner padding and search cancel button in Safari and Chrome on OS X.
- * Safari (but not Chrome) clips the cancel button when the search input has
- * padding (and `textfield` appearance).
- */
-
-input[type="search"]::-webkit-search-cancel-button,
-input[type="search"]::-webkit-search-decoration {
-  -webkit-appearance: none;
-}
-
-/**
- * Define consistent border, margin, and padding.
- */
+// /**
+//  * Change the border, margin, and padding in all browsers (opinionated).
+//  */
 
 fieldset {
   border: 1px solid #c0c0c0;
@@ -379,46 +361,64 @@ fieldset {
   padding: 0.35em 0.625em 0.75em;
 }
 
-/**
- * 1. Correct `color` not being inherited in IE 8/9/10/11.
- * 2. Remove padding so people aren't caught out if they zero out fieldsets.
- */
+// /**
+//  * 1. Correct the text wrapping in Edge and IE.
+//  * 2. Correct the color inheritance from `fieldset` elements in IE.
+//  * 3. Remove the padding so developers are not caught out when they zero out
+//  *    `fieldset` elements in all browsers.
+//  */
 
 legend {
-  border: 0; /* 1 */
-  padding: 0; /* 2 */
+  box-sizing: border-box; // /* 1 */
+  color: inherit; // /* 2 */
+  display: table; // /* 1 */
+  max-width: 100%; // /* 1 */
+  padding: 0;//  /* 3 */
+  white-space: normal; // /* 1 */
 }
 
-/**
- * Remove default vertical scrollbar in IE 8/9/10/11.
- */
+// /**
+//  * Remove the default vertical scrollbar in IE.
+//  */
 
 textarea {
   overflow: auto;
 }
 
-/**
- * Don't inherit the `font-weight` (applied by a rule above).
- * NOTE: the default cannot safely be changed in Chrome and Safari on OS X.
- */
+// /**
+//  * 1. Add the correct box sizing in IE 10-.
+//  * 2. Remove the padding in IE 10-.
+//  */
 
-optgroup {
-  font-weight: bold;
+[type="checkbox"],
+[type="radio"] {
+  box-sizing: border-box; // /* 1 */
+  padding: 0; // /* 2 */
 }
 
-/* Tables
-   ========================================================================== */
+// /**
+//  * Correct the cursor style of increment and decrement buttons in Chrome.
+//  */
 
-/**
- * Remove most spacing between table cells.
- */
-
-table {
-  border-collapse: collapse;
-  border-spacing: 0;
+[type="number"]::-webkit-inner-spin-button,
+[type="number"]::-webkit-outer-spin-button {
+  height: auto;
 }
 
-td,
-th {
-  padding: 0;
+// /**
+//  * Correct the odd appearance of search inputs in Chrome and Safari.
+//  */
+
+[type="search"] {
+  -webkit-appearance: textfield;
+}
+
+// /**
+//  * Remove the inner padding and cancel buttons in Chrome on OS X and
+//  * Safari on OS X.
+//  */
+
+[type="search"]::-webkit-search-cancel-button,
+[type="search"]::-webkit-search-decoration {
+  -webkit-appearance: none;
 }


### PR DESCRIPTION
This branch does 2 things.
- Updates base/_normalize to 4.0
  https://github.com/necolas/normalize.css/blob/master/CHANGELOG.md
- Puts `//` comments before all `/* */` comments so that the sass compiler removes them, resulting in a smaller filesize.

Results in 5k smaller `solid.css` file.
