### PR TITLE
SOLID-314 Modal Interior Window Scroll Bug

### DIFF
--- a/_lib/solid-components/_modals.scss
+++ b/_lib/solid-components/_modals.scss
@@ -15,6 +15,8 @@
   opacity: 0;
   visibility: hidden;
   transition: all .2s;
+  overflow-x: hidden;
+  overflow-y: auto;
 }
 
 


### PR DESCRIPTION
Fixed a bug where the modal wouldn't scroll if the content was too tall.

In order to test this, open the Modals page, then launch the modal. Make your browser as short as you need to so that the modal gets cut off vertically. You'll see that now the entire page scrolls (but not the content behind it).
