### PR TITLE
Actually Deprecate Old Color Classes

### DIFF
--- a/_lib/solid-utilities/_colors.scss
+++ b/_lib/solid-utilities/_colors.scss
@@ -50,10 +50,10 @@
 
 // @TODO remove in version
 // -------------------------
-.fill-red-lighter {      background-color: $fill-red-lighter    !important; }
-.fill-yellow-lighter {   background-color: $fill-yellow-lighter !important; }
-.fill-green-lighter {    background-color: $fill-green-lighter  !important; }
-.fill-gray-lighter {     background-color: $fill-gray-lighter   !important; }
-.fill-gray-darker {      background-color: $fill-gray-darker    !important; }
-.text-gray-lighter {     color: $text-gray-lighter              !important; }
-.text-gray-lightest {    color: $text-gray-lightest             !important; }
+.fill-red--lighter {      background-color: $fill-red-lighter    !important; }
+.fill-yellow--lighter {   background-color: $fill-yellow-lighter !important; }
+.fill-green--lighter {    background-color: $fill-green-lighter  !important; }
+.fill-gray--lighter {     background-color: $fill-gray-lighter   !important; }
+.fill-gray--darker {      background-color: $fill-gray-darker    !important; }
+.text-gray--lighter {     color: $text-gray-lighter              !important; }
+.text-gray--lightest {    color: $text-gray-lightest             !important; }


### PR DESCRIPTION
- added double dashes to the color classes we were supposed to have deprecated in 1.5.1
- (sorry)
- (we need to do better code reviews)
