### PR TITLE
Solid-338 Decrease Size of Checkbox and Radio Labels

### DIFF
--- a/_lib/solid-utilities/_forms.scss
+++ b/_lib/solid-utilities/_forms.scss
@@ -86,7 +86,7 @@ select::-ms-expand,
   @include visuallyhidden;
 
   + label {
-    font-size: $text-5;
+    font-size: $text-5          !important;
     cursor: pointer             !important;
     display: block              !important;
     @include option-input-style;
@@ -105,7 +105,7 @@ select::-ms-expand,
   @include visuallyhidden;
 
   + label {
-    font-size: $text-5;
+    font-size: $text-5            !important;
     cursor: pointer               !important;
     display: block                !important;
     @include option-input-style;


### PR DESCRIPTION
At first glance, it seemed fine that the labels for checks/radios was 16px (text-4), but out in the real world, designers have found that this type size is too big. It's especially obvious when the text string is long. The text size is not proportional to the size of the checkbox and radio itself, as seen here: http://take.ms/8WTAu

My proposal is to decrease the size of these labels to text-5 (14px). Designers are already overriding the labels in their work to use this size.

Here is the comparison:
![new-labels](https://cloud.githubusercontent.com/assets/6640853/14322594/74c378da-fbeb-11e5-9451-70631eaae540.png)
