### PR TITLE
SOLID-297: Remove display: block !important from form labels

### DIFF
--- a/_lib/solid-utilities/_forms.scss
+++ b/_lib/solid-utilities/_forms.scss
@@ -87,7 +87,7 @@ select::-ms-expand,
 
   + label {
     cursor: pointer             !important;
-    display: block              !important;
+    display: block                        ;
     @include option-input-style;
 
     &:before { border-radius: 50% !important; }


### PR DESCRIPTION
2 instances on lines `90`, `108` & `129`.

I have a question about using `!important` liberally in these form styles… If we start allowing inline labels (in this PR), what else should we allow people to override? `.form-feedback`? `input`?
