### PR TITLE
Solid 298 - Adjust Button Hover States

### DIFF
--- a/_lib/solid-utilities/_buttons.scss
+++ b/_lib/solid-utilities/_buttons.scss
@@ -51,10 +51,11 @@
   $secondary-active-background-color: darken($fill-color, 35%);
 
   //base style
-  background-color: $fill-color         !important;
-  color: $text-color                    !important;
-  border-color: $secondary-text-color   !important;
-  border: 1px solid transparent         !important;
+  background-color: $fill-color             !important;
+  color: $text-color                        !important;
+  border-color: $secondary-text-color       !important;
+  border: 1px solid transparent             !important;
+  transition: background-color .1s ease 0s  !important;
 
   //only have hover styles if button is not disabled
   &:not(.button--disabled) {
@@ -72,7 +73,6 @@
     color: $secondary-text-color  !important;
     background: none              !important;
       &:hover {
-      transition: color .18s ease 0s  !important;
       transition: background-color .15s ease 0s  !important;
     }
   }


### PR DESCRIPTION
This PR includes: 

**For all secondary buttons:**
-added back in the active state (was getting overwritten by the hover state because you hover and click at the same time!)

**For all buttons:**
-add easing out on hover

The card originally asked to smooth out the hover transition for secondary buttons. After playing around with changing the transition duration as well as transitioning the text, I wasn't able to achieve anything I thought was worthwhile. I personally don't have a huge problem with this hover state. Interested to know your thoughts, peeps.
