### PR TITLE
SOLID-339: A slightly more responsive release notes page

### DIFF
--- a/release-notes.html
+++ b/release-notes.html
@@ -9,7 +9,7 @@ title: Release Notes
   <div class="release--container clearfix xs-col-12 xs-mb2 xs-pb1">
     {% for post in site.categories.release-notes %}
       <div class="release clearfix xs-mb2 xs-pb1 xs-border-bottom-lighter">
-        <div class="col xs-col-2 lg-col-1 text-gray-lightest">
+        <div class="col xs-col-12 sm-col-2 lg-col-1 text-gray-lightest">
           {{post.version}}
         </div>
         <div class="col xs-col-10 lg-col-11">


### PR DESCRIPTION
Don’t hang the version number on phones.
