### PR TITLE
SOLID-353: Remove !importants on table styles

### DIFF
--- a/_lib/solid-utilities/_tables.scss
+++ b/_lib/solid-utilities/_tables.scss
@@ -1,5 +1,5 @@
 //
-// Table Utility Classes
+// Table Classes
 // --------------------------------------------------
 
 // Border
@@ -8,19 +8,19 @@
 .table-border {
   border:        $border !important;
 
-  th               { border-bottom: $border !important; }
-  tr td            { border-bottom: $border !important; }
-  tr:last-child td { border-bottom: 0       !important; }
+  th               { border-bottom: $border; }
+  tr td            { border-bottom: $border; }
+  tr:last-child td { border-bottom: 0; }
 }
 
-.table-border td, 
+.table-border td,
 .table-border th {
-  padding: .75rem !important;
+  padding: .75rem;
 }
 
 
 
-// Layout
+// Layout Utilities
 // -------------------------
 
 .table {
@@ -29,6 +29,6 @@
   display:         table    !important;
 }
 
-.td, 
+.td,
 .th { display: table-cell !important; }
 .tr { display: table-row !important; }


### PR DESCRIPTION
We were a little aggressive with `!important`s and tables — this fixes that.

With Solid 1.6.3, you can’t override the spacing:
http://codepen.io/niederme/pen/yJeLEv

So, this PR removes `!important` on Table Borders and their spacing, but keeps it on the Table Layout classes:
http://codepen.io/niederme/pen/ZOQerZ

Thanks @capwatkins for reporting.
