### PR TITLE
SOLID-359: Add inertian scrolling to overflows

### DIFF
--- a/_lib/solid-utilities/_layout.scss
+++ b/_lib/solid-utilities/_layout.scss
@@ -12,8 +12,8 @@
 
 @include generate-breakpoint-prefixes {
   &overflow-hidden  { overflow: hidden  !important; }
-  &overflow-auto    { overflow: auto    !important; }
-  &overflow-scroll  { overflow: scroll  !important; }
+  &overflow-auto    { overflow: auto    !important; -webkit-overflow-scrolling: touch; }
+  &overflow-scroll  { overflow: scroll  !important; -webkit-overflow-scrolling: touch; }
   &overflow-visible { overflow: visible !important; }
 
   &hide         { display: none         !important; }


### PR DESCRIPTION
More info here:
https://css-tricks.com/snippets/css/momentum-scrolling-on-ios-overflow-elements/

Demo of this working here (check on iPhone):
http://codepen.io/niederme/pen/VjmoPB

I assume we don’t need to put this on `*-overflow-hidden`, right?
