### PR TITLE
Solid 370 Use Border Variable in Card Component And Shadow Tweak

### DIFF
--- a/_lib/solid-components/_cards.scss
+++ b/_lib/solid-components/_cards.scss
@@ -3,7 +3,7 @@
 // --------------------------------------------------
 
 .card {
-  box-shadow: 0 1px 0 rgba(173, 168, 168, .1);
+  box-shadow: 0 1px 1px rgba(173, 168, 168, .1);
   border: $border-lighter;
   background-color: $fill-white;
   border-radius: $border-radius;


### PR DESCRIPTION
- replaced custom border color with our border variable in the SCSS for Cards
- tweaked the card shadow to be simpler and slightly smaller/lighter
