### PR TITLE
Fix documentation for inline error / warning messaging

### DIFF
--- a/docs/forms.html
+++ b/docs/forms.html
@@ -268,7 +268,7 @@ title: Forms
   <a name="form-errors"></a>
   <h2 class="xs-mb2 bold">Form Errors</h2>
 
-  <p class="xs-mb4">Wrap each field in a <code class="js-highlight">fieldset</code> and add a <span class="nowrap">.<code class="js-highlight">form-fieldset--warning</code></span> class to change the child <code class="js-highlight">label</code></span> and form field styling. Additionally, add a <code class="js-highlight">span</code> below the input with a <span class="nowrap">.<code class="js-highlight">form-feedback</code></span> class to inform the user what needs to be adjusted.</p>
+  <p class="xs-mb4">Wrap each field in a <code class="js-highlight">fieldset</code> and add a <span class="nowrap">.<code class="js-highlight">form-fieldset--error</code></span> class to change the child <code class="js-highlight">label</code></span> and form field styling. Additionally, add a <code class="js-highlight">span</code> below the input with a <span class="nowrap">.<code class="js-highlight">form-feedback</code></span> class to inform the user what needs to be adjusted.</p>
 
   <form class="xs-mb4">
     <fieldset class="fieldset form-fieldset--error">


### PR DESCRIPTION
Our current documentation for form fieldset--error mistakenly says to add the fieldset--warning class where should say --error. Fixed so the docs are consistent with how this works.