### PR TITLE
SOLD-386: Toggling Checkboxes/Radios Within List Causes Parent to Scroll in Google Chrome

### DIFF
--- a/_lib/solid-utilities/_forms.scss
+++ b/_lib/solid-utilities/_forms.scss
@@ -89,6 +89,9 @@ select::-ms-expand,
 .radio {
   @include visuallyhidden;
 
+  // Override for Chrome bug where height collapses on toggle
+  height: 0px;
+
   + label {
     font-size: $text-5          !important;
     cursor: pointer             !important;
@@ -112,6 +115,9 @@ select::-ms-expand,
 // hide system checkbox in order to use custom style
 .checkbox {
   @include visuallyhidden;
+
+  // Override for Chrome bug where height collapses on toggle
+  height: 0px;
 
   + label {
     font-size: $text-5            !important;


### PR DESCRIPTION
-Fixes bug with scroll bar jumping during toggle in Google Chrome (See bug ticket for additional details on how to reproduce)
