### PR TITLE
SOLID-399 Fix error in docs for generate breakpoint prefix mixin

### DIFF
--- a/docs/mixins.html
+++ b/docs/mixins.html
@@ -37,7 +37,7 @@ title: SASS Mixins
   <div class="xs-mb2">
   {% highlight scss %}
   @include generate-breakpoint-prefixes {
-    .class-that-needs-responsive-prefixing {
+    &class-that-needs-responsive-prefixing {
     };
   }
   {% endhighlight %}


### PR DESCRIPTION
- add `&` and remove `.` from targeted selector.