### PR TITLE
SOLID-398 Tweak icon docs

### DIFF
--- a/docs/svg-icons.html
+++ b/docs/svg-icons.html
@@ -120,7 +120,7 @@ title: SVG Icons
 			<title>Success</title>
 			<path d="M19 0C8.5 0 0 8.5 0 19s8.5 19 19 19 19-8.5 19-19S29.5 0 19 0zm0 24.8c-1.6 1.6-4.2 1.6-5.8 0l-5.4-5.4 2.9-2.9 5.4 5.4 11-11 2.9 2.9-11 11z"/>
 		</svg>
-		<span class="xs-text-4 text-green">Post was published successfully.</span>
+		<span class="xs-text-4 xs-ml05 text-green">Post was published successfully.</span>
 	</div>
 
   <!-- Code Snippet: decorative icon -->


### PR DESCRIPTION
-Add half space of padding between icon and text in accessibility example for svg icons docs