### PR TITLE
SOLID-367 Remove Override For Button Focus Outline

### DIFF
--- a/_lib/solid-utilities/_buttons.scss
+++ b/_lib/solid-utilities/_buttons.scss
@@ -28,7 +28,6 @@
   @include prefix((appearance: none), webkit);
   @include prefix((user-select: none));
 
-  &,
   &:active {
     outline: 0 !important;
   }

--- a/_lib/solid-utilities/_buttons.scss
+++ b/_lib/solid-utilities/_buttons.scss
@@ -29,7 +29,7 @@
   @include prefix((user-select: none));
 
   &,
-  &:active:focus {
+  &:active {
     outline: 0 !important;
   }
 }


### PR DESCRIPTION
Removed outline override for button focus and just left it on :active

Tab through the Buttons page in the Solid docs to see the change. Unfortunately this DOES show up on click because technically you are still focused while you're clicking. I think this is the best solution for now. We can alert designers and solicit feedback from them, but I think the benefits outweigh the negatives here.