### PR TITLE
SOLID-407: Add Text-Gray To Body Copy

### DIFF
--- a/_lib/solid-base/_typography.scss
+++ b/_lib/solid-base/_typography.scss
@@ -10,6 +10,7 @@ html {
 body {
   font-size:   $text-4;
   line-height: $line-height-3;
+  color:       $text-gray;
 }
 
 h1 {

--- a/docs/colors.html
+++ b/docs/colors.html
@@ -216,7 +216,7 @@ title: Colors
       .<code class="js-highlight xs-mr1">text-gray</code>
       <span class="xs-text-5 text-gray-lightest">#222222, $text-gray</span>
     </p>
-    <p>This is the darkest gray and default text color.</p>
+    <p class="text-gray">This is the darkest gray and default text color.</p>
   </div>
 
   <div class="xs-mb4">


### PR DESCRIPTION
- Added text-gray to `body`, so we now have default body copy for reals.
- Fixed Colors docs to use the `text-gray` class where it says it's being used.