### PR TITLE
Release 2.6.0

### DIFF
--- a/docs/_posts/release-notes/2017-01-20-2.6.0.html
+++ b/docs/_posts/release-notes/2017-01-20-2.6.0.html
@@ -1,0 +1,17 @@
+---
+category: release-notes
+version: 2.6.0
+title: The Teal and Purple Show
+
+breaking-changes:
+
+potential-breaking-changes:
+
+added:
+  - Teal and purple fill and SVG fill colors
+  - Purple text color
+  - Apple News and RSS social buttons
+  - Body copy is now <span class="nowrap">.<code class="js-highlight">text-gray</code></span> as default
+
+release-notes:
+---

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "bf-solid",
-  "version": "2.5.1",
+  "version": "2.6.0",
   "dependencies": {
     "ansi-regex": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bf-solid",
-  "version": "2.5.1",
+  "version": "2.6.0",
   "description": "Solid CSS Styling",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
Added: Teal and purple fill and SVG fill colors
Added: Purple text color
Added: Apple News and RSS social buttons
Added: Body copy is now .text-gray as default