### PR TITLE
SOLID-404: SVG hover states

### DIFF
--- a/_lib/solid-base/_typography.scss
+++ b/_lib/solid-base/_typography.scss
@@ -63,10 +63,18 @@ h6.slab {
 a {
   text-decoration: none; 
   color: $text-blue;
+  path {
+    fill: $text-blue;
+    }
 
   &:hover {
     color: darken($text-blue, 20%);
     transition: color .15s ease 0s;
+    path {
+          transition: fill .15s ease 0s;
+          fill: darken($text-blue, 20%);
+          cursor: pointer;
+        }
   }
 }
 

--- a/_lib/solid-utilities/_typography.scss
+++ b/_lib/solid-utilities/_typography.scss
@@ -120,22 +120,70 @@
 
 .link-blue {
   color: $text-blue !important;
-  &:hover { color: darken($text-blue, 20%) !important; }
+
+  path {
+    fill: $text-blue !important;
+    }
+
+  &:hover { color: darken($text-blue, 20%) !important; 
+    
+    path {
+      transition: fill .15s ease 0s;
+      fill: darken($text-blue, 20%) !important;
+      cursor: pointer;
+    }
+  }
 }
 
 .link-gray {
   color: $text-gray !important;
-  &:hover { color: $text-blue !important; }
+  
+  path {
+    fill: $text-gray !important;
+    }
+
+  &:hover { color: $text-blue !important;
+  
+    path {
+        transition: fill .15s ease 0s;
+        fill: $text-blue !important;
+        cursor: pointer;
+    }
+  }
 }
 
 .link-gray-lighter {
   color: $text-gray-lightest !important;
-  &:hover { color: $text-gray !important; }
+
+  path {
+    fill: $text-gray-lightest !important;
+    }
+
+  &:hover { color: $text-gray !important; 
+
+    path {
+        transition: fill .15s ease 0s;
+        fill: $text-gray !important;
+        cursor: pointer;
+    }
+  }
 }
 
 .link-white {
   color: $text-white !important;
-  &:hover { color: darken($text-white, 20%) !important; }
+
+  path {
+    fill: $text-white !important;
+    }
+
+  &:hover { color: darken($text-white, 20%) !important; 
+
+    path {
+        transition: fill .15s ease 0s;
+        fill: darken($text-white, 20%) !important;
+        cursor: pointer;
+    }
+  }
 }
 
 


### PR DESCRIPTION
Adds support for hover states in default links, link-blue, link-gray, and link-gray-lighter by transitioning svg fill colors