### PR TITLE
SOLID-418: solid: fix flash of invisible text

### DIFF
--- a/_lib/solid-base/_base.scss
+++ b/_lib/solid-base/_base.scss
@@ -30,7 +30,6 @@ td {
   padding: 0;
   border: 0;
   font-size: 100%;
-  font: inherit;
   vertical-align: baseline;
 }
 
@@ -56,7 +55,6 @@ ul,
 li {
   margin: 0;
   padding: 0;
-  font: inherit;
 }
 
 


### PR DESCRIPTION
Currently, the homepage suffers a Flash of Invisible Text (FOIT) when the fonts are loaded.

![image](https://cloud.githubusercontent.com/assets/352881/23772851/67987454-04d1-11e7-9f93-2468ce42199c.png)

I found the culprit `font: inherit`. 
Because we have [that system](https://github.com/bramstein/fontfaceobserver) to lazy load fonts where we set `font-family` in `body` and then update when `.fonts-loaded` is added, it seems that `font: inherit` breaks that expectation since `body` is in charge of that.