### PR TITLE
SOLID-419 Fix SVG hover and release bugs

### DIFF
--- a/_lib/solid-base/_typography.scss
+++ b/_lib/solid-base/_typography.scss
@@ -63,18 +63,10 @@ h6.slab {
 a {
   text-decoration: none; 
   color: $text-blue;
-  path {
-    fill: $text-blue;
-    }
 
   &:hover {
     color: darken($text-blue, 20%);
     transition: color .15s ease 0s;
-    path {
-          transition: fill .15s ease 0s;
-          fill: darken($text-blue, 20%);
-          cursor: pointer;
-        }
   }
 }
 

--- a/docs/_posts/release-notes/2017-03-10-2.6.1.html
+++ b/docs/_posts/release-notes/2017-03-10-2.6.1.html
@@ -8,8 +8,8 @@ breaking-changes:
 potential-breaking-changes:
 
 added:
-  - Default hover states for SVGs that appear within <code class="js-highlight"><a></code></span> tags
+  - Default hover states for SVGs that appear within <code class="js-highlight">a</code></span> tags
 
 release-notes:
-  - Removed font reset (font: inherit) from Meyer's reset styles to remove instances of FOIT (flash of invisible text).
+  - Removed font reset from Meyer's reset styles to remove instances of FOIT.
 ---


### PR DESCRIPTION
- Reduces reach of svg hover styles to target svgs appearing within explicitly called .link-blue, .link-gray, .link-gray-lighter, and .link-white classes only. 
- Additionally fixes two bugs on previous release notes - closes an a tag and fixes unexpected formatting due to parentheses.