### PR TITLE
Solid 421 flex between around

### DIFF
--- a/_lib/solid-utilities/_flexbox.scss
+++ b/_lib/solid-utilities/_flexbox.scss
@@ -38,7 +38,7 @@
   &flex-align-end           { align-items: flex-end           !important; }
   &flex-align-center        { align-items: center             !important; }
   &flex-align-baseline      { align-items: baseline           !important; }
-  &flex-align-space-around  { align-content: space-around     !important; }
-  &flex-align-space-between { align-content: space-between    !important; }
+  &flex-align-space-around  { align-items: space-around     !important; }
+  &flex-align-space-between { align-items: space-between    !important; }
 
 }

--- a/_lib/solid-utilities/_flexbox.scss
+++ b/_lib/solid-utilities/_flexbox.scss
@@ -34,10 +34,11 @@
   &flex-justify-space-between { justify-content: space-between  !important; }
 
   // align items
-
-  &flex-align-start    { align-items: flex-start         !important; }
-  &flex-align-end      { align-items: flex-end           !important; }
-  &flex-align-center   { align-items: center             !important; }
-  &flex-align-baseline { align-items: baseline           !important; }
+  &flex-align-start         { align-items: flex-start         !important; }
+  &flex-align-end           { align-items: flex-end           !important; }
+  &flex-align-center        { align-items: center             !important; }
+  &flex-align-baseline      { align-items: baseline           !important; }
+  &flex-align-space-around  { align-content: space-around     !important; }
+  &flex-align-space-between { align-content: space-between    !important; }
 
 }

--- a/_lib/solid-utilities/_flexbox.scss
+++ b/_lib/solid-utilities/_flexbox.scss
@@ -27,9 +27,11 @@
   &flex-nowrap { flex-wrap: nowrap                       !important; }
 
   // justify content
-  &flex-justify-start  { justify-content: flex-start     !important; }
-  &flex-justify-end    { justify-content: flex-end       !important; }
-  &flex-justify-center { justify-content: center         !important; }
+  &flex-justify-start         { justify-content: flex-start     !important; }
+  &flex-justify-end           { justify-content: flex-end       !important; }
+  &flex-justify-center        { justify-content: center         !important; }
+  &flex-justify-space-around  { justify-content: space-around   !important; }
+  &flex-justify-space-between { justify-content: space-between  !important; }
 
   // align items
 

--- a/docs/_posts/release-notes/2017-03-10-2.6.1.html
+++ b/docs/_posts/release-notes/2017-03-10-2.6.1.html
@@ -8,7 +8,7 @@ breaking-changes:
 potential-breaking-changes:
 
 added:
-  - Default hover states for SVGs that appear within <code class="js-highlight">a</code></span> tags
+  - Default hover states for SVGs that appear within <code class="js-highlight">a</code> tags
 
 release-notes:
   - Removed font reset from Meyer's reset styles to remove instances of FOIT.

--- a/docs/flexbox.html
+++ b/docs/flexbox.html
@@ -15,7 +15,7 @@ title: Flexbox
 
 </section>
 
-<table class="table-border xs-mb4">
+<table class="table-border xs-mb5">
   <tr>
     <th>Class</th>
     <th>Description</th>
@@ -27,19 +27,31 @@ title: Flexbox
   <tr>
     <td><a href="flexbox.html#justify-content">Justify Content</a></td>
     <td>
-      <span class="nowrap">.<code class="js-highlight">xs-flex-justify-start</code></span>, <span class="nowrap">.<code class="js-highlight">xs-flex-justify-end</code></span>, <span class="nowrap">.<code class="js-highlight">xs-flex-justify-center</code></span>, <span class="nowrap">.<code class="js-highlight">xs-flex-justify-space-between</code></span>, <span class="nowrap">.<code class="js-highlight">xs-flex-space-around</code></span>
+      <span class="nowrap">.<code class="js-highlight">xs-flex-justify-start</code></span>,
+      <span class="nowrap">.<code class="js-highlight">xs-flex-justify-end</code></span>,
+      <span class="nowrap">.<code class="js-highlight">xs-flex-justify-center</code></span>,
+      <span class="nowrap">.<code class="js-highlight">xs-flex-justify-space-between</code></span>,
+      <span class="nowrap">.<code class="js-highlight">xs-flex-justify-space-around</code></span>
     </td>
   </tr>
   <tr>
     <td><a href="flexbox.html#align-items">Align Items</a></td>
     <td>
-      <span class="nowrap">.<code class="js-highlight">xs-flex-align-start</code></span>, <span class="nowrap">.<code class="js-highlight">xs-flex-align-end</code></span>, <span class="nowrap">.<code class="js-highlight">xs-flex-align-center</code></span>
+      <span class="nowrap">.<code class="js-highlight">xs-flex-align-start</code></span>,
+      <span class="nowrap">.<code class="js-highlight">xs-flex-align-end</code></span>,
+      <span class="nowrap">.<code class="js-highlight">xs-flex-align-center</code></span>
+      <span class="nowrap">.<code class="js-highlight">xs-flex-align-space-between</code></span>,
+      <span class="nowrap">.<code class="js-highlight">xs-flex-align-space-around</code></span>
     </td>
   </tr>
   <tr>
     <td><a href="flexbox.html#grow-shrink">Grow & Shrink</a></td>
     <td>
-      <span class="nowrap">.<code class="js-highlight">xs-flex-grow-1</code></span>, <span class="nowrap">.<code class="js-highlight">xs-flex-grow-2</code></span>, <span class="nowrap">.<code class="js-highlight">xs-flex-grow-3</code></span>, <span class="nowrap">.<code class="js-highlight">xs-flex-shrink-0</code></span>, <span class="nowrap">.<code class="js-highlight">xs-flex-shrink-1</code></span>
+      <span class="nowrap">.<code class="js-highlight">xs-flex-grow-1</code></span>,
+      <span class="nowrap">.<code class="js-highlight">xs-flex-grow-2</code></span>,
+      <span class="nowrap">.<code class="js-highlight">xs-flex-grow-3</code></span>,
+      <span class="nowrap">.<code class="js-highlight">xs-flex-shrink-0</code></span>,
+      <span class="nowrap">.<code class="js-highlight">xs-flex-shrink-1</code></span>
     </td>
   </tr>
   <tr>
@@ -58,10 +70,10 @@ title: Flexbox
   <a name="order-properties"></a>
   <h2 class="bold xs-mb2" id="justify-content">Justify Content</h2>
   <p class="xs-mb4">Justify-content defines how items are aligned along the <span class="bold">main axis</span>. By default, the main axis is flex-row (left-to-right). If the parent module is defined as flex-column, then justify-content would determine how items are aligned top-to-bottom.</p>
-  
+
   <!-- Example: Justify Content Start -->
   <div class="xs-mb5">
-    .<code class="js-highlight">flex</code>  .<code class="js-highlight">xs-flex-justify-start</code> 
+    .<code class="js-highlight">flex</code>  .<code class="js-highlight">xs-flex-justify-start</code>
     <p class="xs-mb2 xs-ml05">This is the default alignment, which aligns items at the start of the main axis. <span class="bold">Class applies to the parent</span></p>
 
     <div class="flex xs-mb3 xs-p1 xs-border xs-flex-justify-start fill-red-lighter xs-p2">
@@ -81,7 +93,7 @@ title: Flexbox
 
   <!-- Example: Justify Content End -->
   <div class="xs-mb5">
-    .<code class="js-highlight">flex</code>  .<code class="js-highlight">xs-flex-justify-end</code> 
+    .<code class="js-highlight">flex</code>  .<code class="js-highlight">xs-flex-justify-end</code>
     <p class="xs-mb2 xs-ml05">This class aligns items at the end of the main axis.<span class="bold"> Class applies to the parent</span></p>
 
     <div class="flex xs-flex-justify-end xs-mb3 xs-p1 xs-border fill-red-lighter xs-p2">
@@ -101,7 +113,7 @@ title: Flexbox
 
   <!-- Example: Justify Content Center -->
   <div class="xs-mb5">
-    .<code class="js-highlight">flex</code>  .<code class="js-highlight">xs-flex-justify-center</code> 
+    .<code class="js-highlight">flex</code>  .<code class="js-highlight">xs-flex-justify-center</code>
     <p class="xs-mb2 xs-ml05">This class aligns items in the center of the main axis.<span class="bold"> Class applies to the parent</span></p>
 
     <div class="flex xs-flex-justify-center xs-mb3 xs-p1 xs-border fill-red-lighter xs-p2">
@@ -117,10 +129,11 @@ title: Flexbox
   <div class="xs-border xs-p1 xs-mr1 fill-yellow-lighter text-gray">item three</div>
 </div>
 {% endhighlight %}
-    
+</div>
+
   <!-- Example: Justify Content Space Between -->
   <div class="xs-mb5">
-    .<code class="js-highlight">flex</code>  .<code class="js-highlight">xs-flex-justify-space-between</code> 
+    .<code class="js-highlight">flex</code>  .<code class="js-highlight">xs-flex-justify-space-between</code>
     <p class="xs-mb2 xs-ml05">This class aligns items in an evenly distributed manner on the main axis, but with the first and last item at the start and end of the main axis respectively.<span class="bold"> Class applies to the parent</span></p>
 
     <div class="flex xs-flex-justify-space-between xs-mb3 xs-p1 xs-border fill-red-lighter xs-p2">
@@ -137,11 +150,11 @@ title: Flexbox
 </div>
 {% endhighlight %}
   </div>
-    
+
     <!-- Example: Justify Content Space Around -->
   <div class="xs-mb5">
-    .<code class="js-highlight">flex</code>  .<code class="js-highlight">xs-flex-justify-space-around</code> 
-    <p class="xs-mb2 xs-ml05">This class aligns items in an evenly distributed manner with equal space around each one on the main axis. Note that visually the spaces aren't equal, since all the items have equal space on both sides. The first item will have one unit of space against the container edge, but two units of space between the next item because that next item has its own spacing that applies.<span class="bold"> Class applies to the parent</span></p>
+    .<code class="js-highlight">flex</code>  .<code class="js-highlight">xs-flex-justify-space-around</code>
+    <p class="xs-mb2 xs-ml05">This class aligns items in an evenly distributed manner, with equal space around each item on the main axis.<span class="bold"> Class applies to the parent</span></p>
 
     <div class="flex xs-flex-justify-space-around xs-mb3 xs-p1 xs-border fill-red-lighter xs-p2">
       <div class="xs-border xs-p1 xs-mr1 fill-yellow-lighter text-gray">item one</div>
@@ -167,10 +180,10 @@ title: Flexbox
   <a name="order-properties"></a>
   <h2 class="bold xs-mb2" id="align-items">Align Items</h2>
   <p class="xs-mb4">Align-items defines how items are aligned along the <span class="bold">cross axis</span>. By default, the cross axis direction is top to bottom.</p>
-  
+
   <!-- Example: Align Items Start -->
   <div class="xs-mb5">
-    .<code class="js-highlight">flex</code>  .<code class="js-highlight">xs-flex-align-start</code> 
+    .<code class="js-highlight">flex</code>  .<code class="js-highlight">xs-flex-align-start</code>
     <p class="xs-mb2 xs-ml05">This aligns flex items at the top, or start, of the cross axis. <span class="bold">Class applies to the parent</span></p>
 
     <div class="flex xs-flex-align-start xs-mb3 xs-p1 xs-border fill-red-lighter xs-p2">
@@ -190,7 +203,7 @@ title: Flexbox
 
   <!-- Example: Align Items End -->
   <div class="xs-mb5">
-    .<code class="js-highlight">flex</code>  .<code class="js-highlight">xs-flex-align-end</code> 
+    .<code class="js-highlight">flex</code>  .<code class="js-highlight">xs-flex-align-end</code>
     <p class="xs-mb2 xs-ml05">This aligns flex items at the bottom, or end, of the cross axis. <span class="bold">Class applies to the parent</span></p>
 
     <div class="flex xs-flex-align-end xs-mb3 xs-p1 xs-border fill-red-lighter xs-p2">
@@ -210,7 +223,7 @@ title: Flexbox
 
   <!-- Example: Align Items Center -->
   <div class="xs-mb5">
-    .<code class="js-highlight">flex</code>  .<code class="js-highlight">xs-flex-align-center</code> 
+    .<code class="js-highlight">flex</code>  .<code class="js-highlight">xs-flex-align-center</code>
     <p class="xs-mb2 xs-ml05">This aligns flex items in the middle of the cross axis. <span class="bold">Class applies to the parent</span></p>
 
     <div class="flex xs-flex-align-center xs-mb3 xs-p1  xs-border fill-red-lighter xs-p2">
@@ -237,7 +250,7 @@ title: Flexbox
 
   <!-- Example: Flex Grow 1-->
   <div class="xs-mb5">
-    .<code class="js-highlight">xs-flex-grow-1</code> 
+    .<code class="js-highlight">xs-flex-grow-1</code>
     <p class="xs-mb2 xs-ml05">Setting flex-grow to 1 on a given item allows it to grow if necessary. It takes all the available space inside a flex container that the remaining items do not. <span class="bold">Class applies to the child.</span></p>
 
     <div class="flex xs-mb3">
@@ -320,7 +333,7 @@ title: Flexbox
 
   <!-- Flex Row -->
   <div class="xs-mb5">
-    .<code class="js-highlight">flex</code>  .<code class="js-highlight">xs-flex-row</code> 
+    .<code class="js-highlight">flex</code>  .<code class="js-highlight">xs-flex-row</code>
     <p class="xs-mb2 xs-ml05">This is the default flex direction, which defines the direction of items as left-to-right. <span class="bold">Class applies to the parent.</span></p>
 
     <div class="flex xs-flex-row xs-mb3">

--- a/docs/flexbox.html
+++ b/docs/flexbox.html
@@ -27,7 +27,7 @@ title: Flexbox
   <tr>
     <td><a href="flexbox.html#justify-content">Justify Content</a></td>
     <td>
-      <span class="nowrap">.<code class="js-highlight">xs-flex-justify-start</code></span>, <span class="nowrap">.<code class="js-highlight">xs-flex-justify-end</code></span>, <span class="nowrap">.<code class="js-highlight">xs-flex-justify-center</code></span>
+      <span class="nowrap">.<code class="js-highlight">xs-flex-justify-start</code></span>, <span class="nowrap">.<code class="js-highlight">xs-flex-justify-end</code></span>, <span class="nowrap">.<code class="js-highlight">xs-flex-justify-center</code></span>, <span class="nowrap">.<code class="js-highlight">xs-flex-justify-space-between</code></span>, <span class="nowrap">.<code class="js-highlight">xs-flex-space-around</code></span>
     </td>
   </tr>
   <tr>
@@ -112,6 +112,45 @@ title: Flexbox
 
 {% highlight html %}
 <div class="flex xs-flex-justify-center xs-mb3 xs-p1 xs-border fill-red-lighter xs-p2">
+  <div class="xs-border xs-p1 xs-mr1 fill-yellow-lighter text-gray">item one</div>
+  <div class="xs-border xs-p1 xs-mr1 fill-yellow-lighter text-gray">item two</div>
+  <div class="xs-border xs-p1 xs-mr1 fill-yellow-lighter text-gray">item three</div>
+</div>
+{% endhighlight %}
+    
+  <!-- Example: Justify Content Space Between -->
+  <div class="xs-mb5">
+    .<code class="js-highlight">flex</code>  .<code class="js-highlight">xs-flex-justify-space-between</code> 
+    <p class="xs-mb2 xs-ml05">This class aligns items in an evenly distributed manner on the main axis, but with the first and last item at the start and end of the main axis respectively.<span class="bold"> Class applies to the parent</span></p>
+
+    <div class="flex xs-flex-justify-space-between xs-mb3 xs-p1 xs-border fill-red-lighter xs-p2">
+      <div class="xs-border xs-p1 xs-mr1 fill-yellow-lighter text-gray">item one</div>
+      <div class="xs-border xs-p1 xs-mr1 fill-yellow-lighter text-gray">item two</div>
+      <div class="xs-border xs-p1 xs-mr1 fill-yellow-lighter text-gray">item three</div>
+    </div>
+
+{% highlight html %}
+<div class="flex xs-flex-justify-space-between xs-mb3 xs-p1 xs-border fill-red-lighter xs-p2">
+  <div class="xs-border xs-p1 xs-mr1 fill-yellow-lighter text-gray">item one</div>
+  <div class="xs-border xs-p1 xs-mr1 fill-yellow-lighter text-gray">item two</div>
+  <div class="xs-border xs-p1 xs-mr1 fill-yellow-lighter text-gray">item three</div>
+</div>
+{% endhighlight %}
+  </div>
+    
+    <!-- Example: Justify Content Space Around -->
+  <div class="xs-mb5">
+    .<code class="js-highlight">flex</code>  .<code class="js-highlight">xs-flex-justify-space-around</code> 
+    <p class="xs-mb2 xs-ml05">This class aligns items in an evenly distributed manner with equal space around each one on the main axis. Note that visually the spaces aren't equal, since all the items have equal space on both sides. The first item will have one unit of space against the container edge, but two units of space between the next item because that next item has its own spacing that applies.<span class="bold"> Class applies to the parent</span></p>
+
+    <div class="flex xs-flex-justify-space-around xs-mb3 xs-p1 xs-border fill-red-lighter xs-p2">
+      <div class="xs-border xs-p1 xs-mr1 fill-yellow-lighter text-gray">item one</div>
+      <div class="xs-border xs-p1 xs-mr1 fill-yellow-lighter text-gray">item two</div>
+      <div class="xs-border xs-p1 xs-mr1 fill-yellow-lighter text-gray">item three</div>
+    </div>
+
+{% highlight html %}
+<div class="flex xs-flex-justify-space-around xs-mb3 xs-p1 xs-border fill-red-lighter xs-p2">
   <div class="xs-border xs-p1 xs-mr1 fill-yellow-lighter text-gray">item one</div>
   <div class="xs-border xs-p1 xs-mr1 fill-yellow-lighter text-gray">item two</div>
   <div class="xs-border xs-p1 xs-mr1 fill-yellow-lighter text-gray">item three</div>

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,0 +1,44 @@
+---
+layout: default
+title: Release Notes
+
+# generates list of release notes from posts in _posts/release-notes
+---
+
+<section class="xs-mb6">
+  <div class="release--container clearfix xs-col-12 xs-mb2 xs-pb1">
+    {% for post in site.categories.release-notes %}
+      <div class="release clearfix xs-mb2 xs-pb1 xs-border-bottom-lighter">
+        <div class="col xs-col-12 sm-col-2 lg-col-1 text-gray-lightest">
+          {{post.version}}
+        </div>
+        <div class="col xs-col-10 lg-col-11">
+          <h4 class="bold">
+            {{post.title}}
+          </h4>
+          <p class="xs-mb1 xs-text-5 text-gray-lightest">{{ post.date | date: '%B %d, %Y' }}</p>
+          <ul>
+            {% for note in post.breaking-changes %}
+             <li class="xs-mb1"><span class="text-red bold">Breaking Change:</span> {{note}}</li>
+            {% endfor %}
+            {% for note in post.potential-breaking-changes %}
+             <li class="xs-mb1"><span class="text-red bold">Potential Breaking Change:</span> {{note}}</li>
+            {% endfor %}
+            {% for note in post.deprecated %}
+             <li class="xs-mb1"><span class="text-orange bold">Deprecated:</span> {{note}}</li>
+            {% endfor %}
+            {% for note in post.added %}
+             <li class="xs-mb1"><span class="text-green bold">Added:</span> {{note}}</li>
+            {% endfor %}
+            {% for note in post.release-notes %}
+             <li class="xs-mb1">{{note}}</li>
+            {% endfor %}
+          </ul>
+        </div>
+      </div>
+    {% endfor %}
+  </div>
+  
+</section>
+
+</section>


### PR DESCRIPTION
Added styles for
```
justify-content: space-between
justify-content: space-between
align-items: space-between
align-items: space-between
```

This was originally based off of this branch by this awesome contributor! 
https://github.com/buzzfeed/solid/pull/458

I tweaked the copy on this original PR and added the space-between/space-around styles for align-items (the original branch only had this for justify-content).
