### PR TITLE
SOLID-438 reset header elements to normal font weights

### DIFF
--- a/_lib/solid-base/_typography.scss
+++ b/_lib/solid-base/_typography.scss
@@ -43,6 +43,10 @@ h6 {
   line-height: $line-height-2;
 }
 
+//  Unbold header elements by default
+h1, h2, h3, h4, h5, h6 {
+  font-weight: normal;
+}
 
 // Caponi should never be an h6 or .type-6, 
 // these classes disallow that from happening


### PR DESCRIPTION
Adds font-weight: normal (with no importants) to all header elements by default. Counteracts user agent stylesheet change which bolds header elements by default. Issue originally reported on the homepage.

Current: https://www.dropbox.com/s/tzi7bcx0y3329t7/Screenshot%202017-06-28%2010.34.12.png?dl=0
Expected: https://www.dropbox.com/s/mdb57aie1mqm15b/Screenshot%202017-06-28%2010.34.51.png?dl=0