### PR TITLE
Added prefixed flex class & deprecated scss file

### DIFF
--- a/_lib/_solid-base.scss
+++ b/_lib/_solid-base.scss
@@ -10,3 +10,4 @@
 @import "solid-base/base";
 @import "solid-base/typography";
 @import "solid-base/tables";
+@import "solid/deprecated";

--- a/_lib/_solid-base.scss
+++ b/_lib/_solid-base.scss
@@ -10,4 +10,4 @@
 @import "solid-base/base";
 @import "solid-base/typography";
 @import "solid-base/tables";
-@import "solid/deprecated";
+@import "solid-base/deprecated";

--- a/_lib/solid-base/_deprecated.scss
+++ b/_lib/solid-base/_deprecated.scss
@@ -5,7 +5,6 @@
 
 
 // Page Messaging:
-// @TODO Remove in 3.0 (arbitrary)
 
 .page-message {
   position: relative;
@@ -99,6 +98,5 @@
 }
 
 // Non-prefixed flex class
-// @TODO Remove in 3.0 (arbitrary)
 
 .flex { display: flex !important; }

--- a/_lib/solid-base/_deprecated.scss
+++ b/_lib/solid-base/_deprecated.scss
@@ -1,7 +1,11 @@
 //
-// @TODO Remove in 3.0
-// Deprecated Messaging
-// --------------------------------------------------
+// Deprecated SCSS Classes
+// Classes that would cause breaking changes if removed
+// ----------------------------------------------------------
+
+
+// Page Messaging:
+// @TODO Remove in 3.0 (arbitrary)
 
 .page-message {
   position: relative;
@@ -69,7 +73,7 @@
   background-color: $fill-green-lighter;
   color: $text-green;
 
-  .page-message__text, 
+  .page-message__text,
   .page-message__action {
     color: $text-green;
 
@@ -91,5 +95,10 @@
 }
 
 .page-message__action:hover {
-  color: $text-blue;  
+  color: $text-blue;
 }
+
+// Non-prefixed flex class
+// @TODO Remove in 3.0 (arbitrary)
+
+.flex { display: flex !important; }

--- a/_lib/solid-utilities/_flexbox.scss
+++ b/_lib/solid-utilities/_flexbox.scss
@@ -1,6 +1,11 @@
-.flex { display: flex !important; }
+//
+// Flexbox Utility Classes
+// --------------------------------------------------
 
 @include generate-breakpoint-prefixes {
+
+  // flex
+  &flex { display:flex                                   !important; }
 
   // flex order
   &flex-order-1 { order: 1                               !important; }

--- a/docs/flexbox.html
+++ b/docs/flexbox.html
@@ -22,7 +22,7 @@ title: Flexbox
   </tr>
   <tr>
     <td><a href="flexbox.html">Display Flex</a></td>
-    <td><span class="nowrap">.<code class="js-highlight">flex</code></span></td>
+    <td><span class="nowrap">.<code class="js-highlight">xs-flex</code></span></td>
   </tr>
   <tr>
     <td><a href="flexbox.html#justify-content">Justify Content</a></td>
@@ -73,17 +73,17 @@ title: Flexbox
 
   <!-- Example: Justify Content Start -->
   <div class="xs-mb5">
-    .<code class="js-highlight">flex</code>  .<code class="js-highlight">xs-flex-justify-start</code>
+    .<code class="js-highlight">xs-flex</code>  .<code class="js-highlight">xs-flex-justify-start</code>
     <p class="xs-mb2 xs-ml05">This is the default alignment, which aligns items at the start of the main axis. <span class="bold">Class applies to the parent</span></p>
 
-    <div class="flex xs-mb3 xs-p1 xs-border xs-flex-justify-start fill-red-lighter xs-p2">
+    <div class="xs-flex xs-mb3 xs-p1 xs-border xs-flex-justify-start fill-red-lighter xs-p2">
       <div class="xs-border xs-p1 xs-mr1 fill-yellow-lighter text-gray">item one</div>
       <div class="xs-border xs-p1 xs-mr1 fill-yellow-lighter text-gray">item two</div>
       <div class="xs-border xs-p1 xs-mr1 fill-yellow-lighter text-gray">item three</div>
     </div>
 
 {% highlight html %}
-<div class="flex xs-flex-justify-start xs-mb3 xs-p1 xs-border fill-red-lighter xs-p2">
+<div class="xs-flex xs-flex-justify-start xs-mb3 xs-p1 xs-border fill-red-lighter xs-p2">
   <div class="xs-border xs-p1 xs-mr1 fill-yellow-lighter text-gray">item one</div>
   <div class="xs-border xs-p1 xs-mr1 fill-yellow-lighter text-gray">item two</div>
   <div class="xs-border xs-p1 xs-mr1 fill-yellow-lighter text-gray">item three</div>
@@ -93,17 +93,17 @@ title: Flexbox
 
   <!-- Example: Justify Content End -->
   <div class="xs-mb5">
-    .<code class="js-highlight">flex</code>  .<code class="js-highlight">xs-flex-justify-end</code>
+    .<code class="js-highlight">xs-flex</code>  .<code class="js-highlight">xs-flex-justify-end</code>
     <p class="xs-mb2 xs-ml05">This class aligns items at the end of the main axis.<span class="bold"> Class applies to the parent</span></p>
 
-    <div class="flex xs-flex-justify-end xs-mb3 xs-p1 xs-border fill-red-lighter xs-p2">
+    <div class="xs-flex xs-flex-justify-end xs-mb3 xs-p1 xs-border fill-red-lighter xs-p2">
       <div class="xs-border xs-p1 xs-mr1 fill-yellow-lighter text-gray">item one</div>
       <div class="xs-border xs-p1 xs-mr1 fill-yellow-lighter text-gray">item two</div>
       <div class="xs-border xs-p1 xs-mr1 fill-yellow-lighter text-gray">item three</div>
     </div>
 
 {% highlight html %}
-<div class="flex xs-flex-justify-end xs-mb3 xs-p1 xs-border fill-red-lighter xs-p2">
+<div class="xs-flex xs-flex-justify-end xs-mb3 xs-p1 xs-border fill-red-lighter xs-p2">
   <div class="xs-border xs-p1 xs-mr1 fill-yellow-lighter text-gray">item one</div>
   <div class="xs-border xs-p1 xs-mr1 fill-yellow-lighter text-gray">item two</div>
   <div class="xs-border xs-p1 xs-mr1 fill-yellow-lighter text-gray">item three</div>
@@ -113,17 +113,17 @@ title: Flexbox
 
   <!-- Example: Justify Content Center -->
   <div class="xs-mb5">
-    .<code class="js-highlight">flex</code>  .<code class="js-highlight">xs-flex-justify-center</code>
+    .<code class="js-highlight">xs-flex</code>  .<code class="js-highlight">xs-flex-justify-center</code>
     <p class="xs-mb2 xs-ml05">This class aligns items in the center of the main axis.<span class="bold"> Class applies to the parent</span></p>
 
-    <div class="flex xs-flex-justify-center xs-mb3 xs-p1 xs-border fill-red-lighter xs-p2">
+    <div class="xs-flex xs-flex-justify-center xs-mb3 xs-p1 xs-border fill-red-lighter xs-p2">
       <div class="xs-border xs-p1 xs-mr1 fill-yellow-lighter text-gray">item one</div>
       <div class="xs-border xs-p1 xs-mr1 fill-yellow-lighter text-gray">item two</div>
       <div class="xs-border xs-p1 xs-mr1 fill-yellow-lighter text-gray">item three</div>
     </div>
 
 {% highlight html %}
-<div class="flex xs-flex-justify-center xs-mb3 xs-p1 xs-border fill-red-lighter xs-p2">
+<div class="xs-flex xs-flex-justify-center xs-mb3 xs-p1 xs-border fill-red-lighter xs-p2">
   <div class="xs-border xs-p1 xs-mr1 fill-yellow-lighter text-gray">item one</div>
   <div class="xs-border xs-p1 xs-mr1 fill-yellow-lighter text-gray">item two</div>
   <div class="xs-border xs-p1 xs-mr1 fill-yellow-lighter text-gray">item three</div>
@@ -133,17 +133,17 @@ title: Flexbox
 
   <!-- Example: Justify Content Space Between -->
   <div class="xs-mb5">
-    .<code class="js-highlight">flex</code>  .<code class="js-highlight">xs-flex-justify-space-between</code>
+    .<code class="js-highlight">xs-flex</code>  .<code class="js-highlight">xs-flex-justify-space-between</code>
     <p class="xs-mb2 xs-ml05">This class aligns items in an evenly distributed manner on the main axis, but with the first and last item at the start and end of the main axis respectively.<span class="bold"> Class applies to the parent</span></p>
 
-    <div class="flex xs-flex-justify-space-between xs-mb3 xs-p1 xs-border fill-red-lighter xs-p2">
+    <div class="xs-flex xs-flex-justify-space-between xs-mb3 xs-p1 xs-border fill-red-lighter xs-p2">
       <div class="xs-border xs-p1 xs-mr1 fill-yellow-lighter text-gray">item one</div>
       <div class="xs-border xs-p1 xs-mr1 fill-yellow-lighter text-gray">item two</div>
       <div class="xs-border xs-p1 xs-mr1 fill-yellow-lighter text-gray">item three</div>
     </div>
 
 {% highlight html %}
-<div class="flex xs-flex-justify-space-between xs-mb3 xs-p1 xs-border fill-red-lighter xs-p2">
+<div class="xs-flex xs-flex-justify-space-between xs-mb3 xs-p1 xs-border fill-red-lighter xs-p2">
   <div class="xs-border xs-p1 xs-mr1 fill-yellow-lighter text-gray">item one</div>
   <div class="xs-border xs-p1 xs-mr1 fill-yellow-lighter text-gray">item two</div>
   <div class="xs-border xs-p1 xs-mr1 fill-yellow-lighter text-gray">item three</div>
@@ -153,17 +153,17 @@ title: Flexbox
 
     <!-- Example: Justify Content Space Around -->
   <div class="xs-mb5">
-    .<code class="js-highlight">flex</code>  .<code class="js-highlight">xs-flex-justify-space-around</code>
+    .<code class="js-highlight">xs-flex</code>  .<code class="js-highlight">xs-flex-justify-space-around</code>
     <p class="xs-mb2 xs-ml05">This class aligns items in an evenly distributed manner, with equal space around each item on the main axis.<span class="bold"> Class applies to the parent</span></p>
 
-    <div class="flex xs-flex-justify-space-around xs-mb3 xs-p1 xs-border fill-red-lighter xs-p2">
+    <div class="xs-flex xs-flex-justify-space-around xs-mb3 xs-p1 xs-border fill-red-lighter xs-p2">
       <div class="xs-border xs-p1 xs-mr1 fill-yellow-lighter text-gray">item one</div>
       <div class="xs-border xs-p1 xs-mr1 fill-yellow-lighter text-gray">item two</div>
       <div class="xs-border xs-p1 xs-mr1 fill-yellow-lighter text-gray">item three</div>
     </div>
 
 {% highlight html %}
-<div class="flex xs-flex-justify-space-around xs-mb3 xs-p1 xs-border fill-red-lighter xs-p2">
+<div class="xs-flex xs-flex-justify-space-around xs-mb3 xs-p1 xs-border fill-red-lighter xs-p2">
   <div class="xs-border xs-p1 xs-mr1 fill-yellow-lighter text-gray">item one</div>
   <div class="xs-border xs-p1 xs-mr1 fill-yellow-lighter text-gray">item two</div>
   <div class="xs-border xs-p1 xs-mr1 fill-yellow-lighter text-gray">item three</div>
@@ -183,17 +183,17 @@ title: Flexbox
 
   <!-- Example: Align Items Start -->
   <div class="xs-mb5">
-    .<code class="js-highlight">flex</code>  .<code class="js-highlight">xs-flex-align-start</code>
+    .<code class="js-highlight">xs-flex</code>  .<code class="js-highlight">xs-flex-align-start</code>
     <p class="xs-mb2 xs-ml05">This aligns flex items at the top, or start, of the cross axis. <span class="bold">Class applies to the parent</span></p>
 
-    <div class="flex xs-flex-align-start xs-mb3 xs-p1 xs-border fill-red-lighter xs-p2">
+    <div class="xs-flex xs-flex-align-start xs-mb3 xs-p1 xs-border fill-red-lighter xs-p2">
       <div class="xs-border xs-p05 xs-mr1 fill-yellow-lighter text-gray">item one</div>
       <div class="xs-border xs-p1 xs-mr1 fill-yellow-lighter text-gray">item two</div>
       <div class="xs-border xs-p2 xs-mr1 fill-yellow-lighter text-gray">item three</div>
     </div>
 
 {% highlight html %}
-<div class="flex xs-flex-align-start xs-mb3 xs-p1 xs-border fill-red-lighter xs-p2">
+<div class="xs-flex xs-flex-align-start xs-mb3 xs-p1 xs-border fill-red-lighter xs-p2">
   <div class="xs-border xs-p05 xs-mr1 fill-yellow-lighter text-gray">item one</div>
   <div class="xs-border xs-p1 xs-mr1 fill-yellow-lighter text-gray">item two</div>
   <div class="xs-border xs-p2 xs-mr1 fill-yellow-lighter text-gray">item three</div>
@@ -203,17 +203,17 @@ title: Flexbox
 
   <!-- Example: Align Items End -->
   <div class="xs-mb5">
-    .<code class="js-highlight">flex</code>  .<code class="js-highlight">xs-flex-align-end</code>
+    .<code class="js-highlight">xs-flex</code>  .<code class="js-highlight">xs-flex-align-end</code>
     <p class="xs-mb2 xs-ml05">This aligns flex items at the bottom, or end, of the cross axis. <span class="bold">Class applies to the parent</span></p>
 
-    <div class="flex xs-flex-align-end xs-mb3 xs-p1 xs-border fill-red-lighter xs-p2">
+    <div class="xs-flex xs-flex-align-end xs-mb3 xs-p1 xs-border fill-red-lighter xs-p2">
       <div class="xs-border xs-p05 xs-mr1 fill-yellow-lighter text-gray">item one</div>
       <div class="xs-border xs-p1 xs-mr1 fill-yellow-lighter text-gray">item two</div>
       <div class="xs-border xs-p2 xs-mr1 fill-yellow-lighter text-gray">item three</div>
     </div>
 
 {% highlight html %}
-<div class="flex xs-flex-align-end xs-mb3 xs-p1 xs-border fill-red-lighter xs-p2">
+<div class="xs-flex xs-flex-align-end xs-mb3 xs-p1 xs-border fill-red-lighter xs-p2">
   <div class="xs-border xs-p05 xs-mr1 fill-yellow-lighter text-gray">item one</div>
   <div class="xs-border xs-p1 xs-mr1 fill-yellow-lighter text-gray">item two</div>
   <div class="xs-border xs-p2 xs-mr1 fill-yellow-lighter text-gray">item three</div>
@@ -223,17 +223,17 @@ title: Flexbox
 
   <!-- Example: Align Items Center -->
   <div class="xs-mb5">
-    .<code class="js-highlight">flex</code>  .<code class="js-highlight">xs-flex-align-center</code>
+    .<code class="js-highlight">xs-flex</code>  .<code class="js-highlight">xs-flex-align-center</code>
     <p class="xs-mb2 xs-ml05">This aligns flex items in the middle of the cross axis. <span class="bold">Class applies to the parent</span></p>
 
-    <div class="flex xs-flex-align-center xs-mb3 xs-p1  xs-border fill-red-lighter xs-p2">
+    <div class="xs-flex xs-flex-align-center xs-mb3 xs-p1  xs-border fill-red-lighter xs-p2">
       <div class="xs-border xs-p05 xs-mr1 fill-yellow-lighter text-gray">item one</div>
       <div class="xs-border xs-p1 xs-mr1 fill-yellow-lighter text-gray">item two</div>
       <div class="xs-border xs-p2 xs-mr1 fill-yellow-lighter text-gray">item three</div>
     </div>
 
 {% highlight html %}
-<div class="flex xs-flex-align-center xs-mb3 xs-p1 xs-border fill-red-lighter xs-p2">
+<div class="xs-flex xs-flex-align-center xs-mb3 xs-p1 xs-border fill-red-lighter xs-p2">
   <div class="xs-border xs-p05 xs-mr1 fill-yellow-lighter text-gray">item one</div>
   <div class="xs-border xs-p1 xs-mr1 fill-yellow-lighter text-gray">item two</div>
   <div class="xs-border xs-p2 xs-mr1 fill-yellow-lighter text-gray">item three</div>
@@ -253,7 +253,7 @@ title: Flexbox
     .<code class="js-highlight">xs-flex-grow-1</code>
     <p class="xs-mb2 xs-ml05">Setting flex-grow to 1 on a given item allows it to grow if necessary. It takes all the available space inside a flex container that the remaining items do not. <span class="bold">Class applies to the child.</span></p>
 
-    <div class="flex xs-mb3">
+    <div class="xs-flex xs-mb3">
       <div class="xs-p2 xs-border xs-border-right-none fill-yellow-lighter">
         <span class="xs-px2"></span>
       </div>
@@ -266,7 +266,7 @@ title: Flexbox
     </div>
 
 {% highlight html %}
-<div class="flex xs-mb2">
+<div class="xs-flex xs-mb2">
   <div class="xs-p2 xs-border xs-border-right-none fill-yellow-lighter">
     <span class="xs-px2"></span>
   </div>
@@ -290,7 +290,7 @@ title: Flexbox
 
   <!-- Example: Flex Order -->
   <div class="xs-mb5">
-    <div class="flex xs-mb2">
+    <div class="xs-flex xs-mb2">
       <div class="xs-flex-order-3 xs-flex-grow-1 xs-p2 xs-border xs-border-left-none fill-yellow-lighter">
         <span>.xs-flex-order-3</span>
         <span class="xs-block text-gray-lighter">First item in the markup</span>
@@ -306,7 +306,7 @@ title: Flexbox
     </div>
 
 {% highlight html %}
-<div class="flex">
+<div class="xs-flex">
   <div class="xs-flex-order-3 xs-p2 xs-border xs-border-left-none fill-yellow-lighter">
     <span>.xs-flex-order-3</span>
     <span class="xs-block text-gray-lighter">First item in the markup</span>
@@ -333,10 +333,10 @@ title: Flexbox
 
   <!-- Flex Row -->
   <div class="xs-mb5">
-    .<code class="js-highlight">flex</code>  .<code class="js-highlight">xs-flex-row</code>
+    .<code class="js-highlight">xs-flex</code>  .<code class="js-highlight">xs-flex-row</code>
     <p class="xs-mb2 xs-ml05">This is the default flex direction, which defines the direction of items as left-to-right. <span class="bold">Class applies to the parent.</span></p>
 
-    <div class="flex xs-flex-row xs-mb3">
+    <div class="xs-flex xs-flex-row xs-mb3">
       <div class="xs-flex-grow-1 xs-p2 xs-border xs-border-right-none fill-yellow-lighter">
         <span class="xs-block text-gray-lighter">First item in the markup</span>
       </div>
@@ -349,7 +349,7 @@ title: Flexbox
     </div>
 
 {% highlight html %}
-<div class="flex xs-flex-row">
+<div class="xs-flex xs-flex-row">
   <div class="xs-flex-grow-1 xs-p2 xs-border xs-border-right-none fill-yellow-lighter">
     <span class="xs-block text-gray-lighter">First item in the markup</span>
   </div>
@@ -365,10 +365,10 @@ title: Flexbox
 
   <!-- Flex Row Reverse -->
   <div class="xs-mb5">
-    .<code class="js-highlight">flex</code>  .<code class="js-highlight">xs-flex-row-reverse</code>
+    .<code class="js-highlight">xs-flex</code>  .<code class="js-highlight">xs-flex-row-reverse</code>
     <p class="xs-mb2 xs-ml05">This class defines the direction of items as right-to-left. <span class="bold">Class applies to the parent.</span></p>
 
-    <div class="flex xs-flex-row-reverse xs-mb3">
+    <div class="xs-flex xs-flex-row-reverse xs-mb3">
       <div class="xs-flex-grow-1 xs-p2 xs-border xs-border-left-none fill-yellow-lighter">
         <span class="xs-block text-gray-lighter">First item in the markup</span>
       </div>
@@ -381,7 +381,7 @@ title: Flexbox
     </div>
 
 {% highlight html %}
-<div class="flex xs-flex-row-reverse">
+<div class="xs-flex xs-flex-row-reverse">
   <div class="xs-flex-grow-1 xs-p2 xs-border xs-border-left-none fill-yellow-lighter">
     <span class="xs-block text-gray-lighter">First item in the markup</span>
   </div>
@@ -397,10 +397,10 @@ title: Flexbox
 
   <!-- Flex Column -->
   <div class="xs-mb5">
-    .<code class="js-highlight">flex</code>  .<code class="js-highlight">xs-flex-column</code>
+    .<code class="js-highlight">xs-flex</code>  .<code class="js-highlight">xs-flex-column</code>
     <p class="xs-mb2">This class defines the direction of items as top-to-bottom. <span class="bold">Class applies to the parent.</span></p>
 
-    <div class="flex xs-flex-column xs-mb3">
+    <div class="xs-flex xs-flex-column xs-mb3">
       <div class="xs-flex-grow-1 xs-p2 xs-border xs-border-bottom-none fill-yellow-lighter">
         <span class="xs-block text-gray-lighter">First item in the markup</span>
       </div>
@@ -410,7 +410,7 @@ title: Flexbox
     </div>
 
 {% highlight html %}
-<div class="flex xs-flex-column">
+<div class="xs-flex xs-flex-column">
   <div class="xs-flex-grow-1 xs-p2 xs-border xs-border-bottom-none fill-yellow-lighter">
     <span class="xs-block text-gray-lighter">First item in the markup</span>
   </div>
@@ -423,10 +423,10 @@ title: Flexbox
 
   <!-- Flex Column Reverse -->
   <div class="xs-mb5">
-    .<code class="js-highlight">flex</code>  .<code class="js-highlight">xs-flex-column-reverse</code>
+    .<code class="js-highlight">xs-flex</code>  .<code class="js-highlight">xs-flex-column-reverse</code>
     <p class="xs-mb2">This class defines the direction of items as bottom-to-top. <span class="bold">Class applies to the parent.</span></p>
 
-    <div class="flex xs-flex-column-reverse xs-mb3">
+    <div class="xs-flex xs-flex-column-reverse xs-mb3">
       <div class="xs-flex-grow-1 xs-p2 xs-border fill-yellow-lighter">
         <span class="xs-block text-gray-lighter">First item in the markup</span>
       </div>
@@ -436,7 +436,7 @@ title: Flexbox
     </div>
 
 {% highlight html %}
-<div class="flex xs-flex-column-reverse">
+<div class="xs-flex xs-flex-column-reverse">
   <div class="xs-flex-grow-1 xs-p2 xs-border xs-border-bottom-none fill-yellow-lighter">
     <span class="xs-block text-gray-lighter">First item in the markup</span>
   </div>


### PR DESCRIPTION
Added deprecated.scss file: for classes we feel should be deprecated before cold-removing them
Moved the deprecated page messaging styles to that file ☝️ 
Added the prefixed flex display class
Moved non-prefixed flex display class to the new fancy deprecated.scss file (kind of an oxymoron)

Added prefixed flex class to the documentation
