### PR TITLE
Added double-dash to the custom button class mixin

### DIFF
--- a/docs/mixins.html
+++ b/docs/mixins.html
@@ -53,7 +53,7 @@ title: SASS Mixins
 
   <div class="xs-mb2">
   {% highlight scss %}
-.button-custom {
+.button--custom {
   @include button-style($fill-color, $text-color, $secondary-text-color:$fill-color, $secondary-hover-text-color:$text-color);
   }
   {% endhighlight %}


### PR DESCRIPTION
On this page: solid.buzzfeed.com/mixins.html, the custom button class in the code snippet was missing a dash. We typically write modifier classes (like custom button classes that rely on the button class) with double dashes (button button--funtown), and the docs should reflect that. 