### PR TITLE
add full width utility class

### DIFF
--- a/_lib/solid-utilities/_layout.scss
+++ b/_lib/solid-utilities/_layout.scss
@@ -26,9 +26,10 @@
   &float-none  { float: none  !important; }
 
   &fit         { max-width: 100% !important; }
-  &full-height { height: 100%    !important; }
-  &width-auto  { width: auto      !important; }
-  &height-auto { height: auto      !important; }
+  &full-width  { width:     100% !important; }
+  &full-height { height:    100% !important; }
+  &width-auto  { width:     auto !important; }
+  &height-auto { height:    auto !important; }
 
 }
 


### PR DESCRIPTION
This becomes useful when your element is floating. It forces it to take the full width of its parent.