### PR TITLE
add $fill-buzzfeed color

### DIFF
--- a/_lib/solid-helpers/_variables.scss
+++ b/_lib/solid-helpers/_variables.scss
@@ -49,7 +49,7 @@ $z4: 400 !default;
 // Colors
 // -------------------------
 
-// Fills 
+// Fills
 $fill-red:             #e32    !default;
 $fill-red-lighter:     #feebe9 !default;
 $fill-pink:            #f43192 !default;
@@ -68,16 +68,17 @@ $fill-gray-darker:     #222    !default;
 $fill-white:           #fff    !default;
 
 // Social Fills
-$fill-facebook:  #3b5998 !default;
-$fill-twitter:   #55acee !default;
-$fill-google:    #dd4b39 !default;
-$fill-linkedin:  #0077b5 !default;
-$fill-pinterest: #bd081c !default;
-$fill-tumblr:    #36465d !default;
-$fill-youtube:   #cd201f !default;
-$fill-instagram: #517fa4 !default;
-$fill-vine:      #00b488 !default;
-$fill-snapchat:  #fffc00 !default;
+$fill-facebook:  #3b5998    !default;
+$fill-twitter:   #55acee    !default;
+$fill-google:    #dd4b39    !default;
+$fill-linkedin:  #0077b5    !default;
+$fill-pinterest: #bd081c    !default;
+$fill-tumblr:    #36465d    !default;
+$fill-youtube:   #cd201f    !default;
+$fill-instagram: #517fa4    !default;
+$fill-buzzfeed:  $fill-red  !default;
+$fill-vine:      #00b488    !default;
+$fill-snapchat:  #fffc00    !default;
 
 // Type Colors
 $text-white:           #fff    !default;

--- a/_lib/solid-utilities/_colors.scss
+++ b/_lib/solid-utilities/_colors.scss
@@ -82,3 +82,4 @@
 .svg-instagram {         fill: $fill-instagram       !important; }
 .svg-vine {              fill: $fill-vine            !important; }
 .svg-snapchat {          fill: $fill-snapchat        !important; }
+.svg-buzzfeed {          fill: $fill-buzzfeed        !important; }

--- a/_lib/solid-utilities/_colors.scss
+++ b/_lib/solid-utilities/_colors.scss
@@ -36,6 +36,7 @@
 .fill-instagram {         background-color: $fill-instagram       !important; }
 .fill-vine {              background-color: $fill-vine            !important; }
 .fill-snapchat {          background-color: $fill-snapchat        !important; }
+.fill-buzzfeed {          background-color: $fill-buzzfeed        !important; }
 
 // Text Colors
 // -------------------------

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bf-solid",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "description": "Solid CSS Styling",
   "scripts": {
     "prepublish": "grunt dist"

--- a/release-notes/2017-08-22-2.9.0.html
+++ b/release-notes/2017-08-22-2.9.0.html
@@ -1,0 +1,20 @@
+---
+category: release-notes
+version: 2.8.0
+title: Add $fill-buzzfeed color for social and svg.
+
+
+breaking-changes:
+
+potential-breaking-changes:
+
+fixed:
+added:
+- $fill-buzzfeed color (same value as $fill-red)
+- .fill-buzzfeed class
+- .svg-buzzfeed class
+
+deprecated:
+
+release-notes:
+---


### PR DESCRIPTION
We have a few places in dashboard where we map platforms (of which BuzzFeed is one) to solid colors. As we do more with BuzzFeed O&O stats, we need a BuzzFeed solid color.