### PR TITLE
Adjust button white hover color

### DIFF
--- a/_lib/solid-utilities/_buttons.scss
+++ b/_lib/solid-utilities/_buttons.scss
@@ -126,8 +126,12 @@
 .button--white {
   @include button-style($fill-white, $text-gray);
 
-  // white button has unique hover states
-  &.button--secondary:not(.button--disabled):not(:disabled):active { background-color: darken($fill-white, 10%) !important; }
+  // white button has unique hover state
+  &:not(.button--disabled):not(:disabled):hover { 
+    background-color: rgba(255,255,255,.8) !important; 
+  }
+
+  &.button--secondary:not(.button--disabled):not(:disabled):active { background-color: rgba(255,255,255,.8) !important; }
 
   &.button--icon {
     >svg                               { fill: $fill-gray-darker  !important; }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bf-solid",
-  "version": "2.9.1",
+  "version": "2.9.2",
   "description": "Solid CSS Styling",
   "scripts": {
     "prepublish": "grunt dist"

--- a/release-notes/2017-10-18-2.9.2.html
+++ b/release-notes/2017-10-18-2.9.2.html
@@ -1,0 +1,20 @@
+---
+category: release-notes
+version: 2.9.2
+title: Adjusted White Button Hover State
+
+
+breaking-changes:
+
+potential-breaking-changes:
+
+fixed:
+
+added:
+
+deprecated:
+
+release-notes:
+- <span class="nowrap">.<code class="js-highlight">button--white</code></span> now hovers to .8 transparency instead of darkening to a light gray, making it look less dull when placed on dark backgrounds.
+
+---


### PR DESCRIPTION
I'm proposing that we change the white button hover color to an opacity change instead of a darker white (aka gray) because it's super dull on dark backgrounds. And ultimately, you'd ALWAYS use this white button on a dark background. The opacity change on hover is more elegant than the gray.


Current white button hover state (fill darken): http://take.ms/wuQ9w
Proposed white button hover state (opacity change): http://take.ms/Y3Ody