### PR TITLE
updating instagram brand color

### DIFF
--- a/_lib/solid-helpers/_variables.scss
+++ b/_lib/solid-helpers/_variables.scss
@@ -75,7 +75,7 @@ $fill-linkedin:  #0077b5    !default;
 $fill-pinterest: #bd081c    !default;
 $fill-tumblr:    #36465d    !default;
 $fill-youtube:   #FF0000    !default;
-$fill-instagram: #517fa4    !default;
+$fill-instagram: #000000    !default;
 $fill-buzzfeed:  $fill-red  !default;
 $fill-vine:      #00b488    !default;
 $fill-snapchat:  #fffc00    !default;
@@ -101,7 +101,7 @@ $text-linkedin:  #0077b5 !default;
 $text-pinterest: #bd081c !default;
 $text-tumblr:    #36465d !default;
 $text-youtube:   #FF0000 !default;
-$text-instagram: #517fa4 !default;
+$text-instagram: #000000 !default;
 
 // Typography Sizes and Weights
 // -------------------------

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bf-solid",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "description": "Solid CSS Styling",
   "scripts": {
     "prepublish": "grunt dist"

--- a/release-notes/2017-11-29-2.10.1.html
+++ b/release-notes/2017-11-29-2.10.1.html
@@ -1,0 +1,14 @@
+---
+category: release-notes
+version: 2.10.1
+title: New Instagram Brand Color
+
+
+breaking-changes:
+
+potential-breaking-changes:
+
+fixed:
+Instagram changed their glyph icon color to black.
+
+---


### PR DESCRIPTION
Updating Instagram fill and text to match the new recommended brand color: https://en.instagram-brand.com/assets/glyph-icon

Note: I'll also be opening a PR to include this update in the docs.