### PR TITLE
Use the latest grunt version

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
   ],
   "devDependencies": {
     "es6-promise": "^3.0.2",
-    "grunt": "~0.4.5",
+    "grunt": "^1.0.1",
     "grunt-contrib-clean": "^1.1.0",
     "grunt-contrib-compress": "~1.4.1",
     "grunt-contrib-copy": "^1.0.0",


### PR DESCRIPTION
In npm 5.3.0 it attempts to flatten all dependencies. grunt 0.4.5 and grunt-contrib-clean 1.1.0 have conflicting requirements and this cause a build error.

Thankfully updating to 1.0.1 required no application changes!