### PR TITLE
SITE-5296: solid: Make a mixin for the card styles

### DIFF
--- a/_lib/solid-components/_cards.scss
+++ b/_lib/solid-components/_cards.scss
@@ -2,9 +2,13 @@
 // Cards
 // --------------------------------------------------
 
-.card {
+@mixin card {
   box-shadow: 0 1px 1px rgba(173, 168, 168, .1);
   border: $border-lighter;
   background-color: $fill-white;
   border-radius: $border-radius;
+}
+
+.card {
+  @include card();
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bf-solid",
-  "version": "2.10.3",
+  "version": "2.11.0",
   "description": "Solid CSS Styling",
   "scripts": {
     "prepublish": "grunt dist"

--- a/release-notes/2017-12-13-2.11.0.html
+++ b/release-notes/2017-12-13-2.11.0.html
@@ -1,0 +1,8 @@
+---
+category: release-notes
+version: 2.11.0
+title: Mixin for the card styles
+
+added:
+- Mixin `card` that lets copy card styles
+---


### PR DESCRIPTION
Having a mixin for the card styles will allow teams to safely reuse those styles without affecting the original `.card` class.

Before:
```sass
  @import "solid-components/cards";

  .custom-card {
    @extend .card;
  }
```
which compiles to
```css
  .custom-card, .card {
     border: 1px solid rgba(0,0,0,.1);
     border-radius: 3px;
    // ...
  }
```

After:
```sass
  @import "solid-components/cards";

  .custom-card {
    @include card();
  }
```
which compiles to
```css
  .card {
     border: 1px solid rgba(0,0,0,.1);
     border-radius: 3px;
    // ...
  }

  .custom-card {
     border: 1px solid rgba(0,0,0,.1);
     border-radius: 3px;
    // ...
  }
```