### PR TITLE
Popover Top/Bottom fix

### DIFF
--- a/_lib/solid-components/_popovers.scss
+++ b/_lib/solid-components/_popovers.scss
@@ -126,7 +126,7 @@ $popover-fg-caret-size: .525rem;
   }
 }
 
-.popover-top {
+.popover-bottom {
 
   &:before, &:after {
     left: 50%;
@@ -156,7 +156,7 @@ $popover-fg-caret-size: .525rem;
   }
 }
 
-.popover-bottom {
+.popover-top {
 
   &:before, &:after {
     left: 50%;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bf-solid",
-  "version": "2.10.4-test",
+  "version": "2.10.5",
   "description": "Solid CSS Styling",
   "scripts": {
     "prepublish": "grunt dist"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bf-solid",
-  "version": "2.10.5",
+  "version": "2.10.5-test1",
   "description": "Solid CSS Styling",
   "scripts": {
     "prepublish": "grunt dist"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bf-solid",
-  "version": "2.10.4",
+  "version": "2.10.4-test",
   "description": "Solid CSS Styling",
   "scripts": {
     "prepublish": "grunt dist"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bf-solid",
-  "version": "2.10.5-test1",
+  "version": "2.10.6",
   "description": "Solid CSS Styling",
   "scripts": {
     "prepublish": "grunt dist"

--- a/release-notes/2018-01-5-2.10.6.html
+++ b/release-notes/2018-01-5-2.10.6.html
@@ -1,0 +1,15 @@
+---
+category: release-notes
+version: 2.10.6
+title: Popover Fix
+
+
+breaking-changes:
+
+potential-breaking-changes:
+
+fixed:
+-  top and bottom popover classnames were flipped
+
+release-notes:
+---

--- a/release-notes/2018-01-9-2.10.6.html
+++ b/release-notes/2018-01-9-2.10.6.html
@@ -3,13 +3,10 @@ category: release-notes
 version: 2.10.6
 title: Popover Fix
 
-
 breaking-changes:
 
 potential-breaking-changes:
-
-fixed:
--  top and bottom popover classnames were flipped
+  - top and bottom popover classnames were flipped
 
 release-notes:
 ---


### PR DESCRIPTION
top & bottom popover names are flipped by accident

intended behavior 
![screenshot 2018-01-09 13 36 54](https://user-images.githubusercontent.com/586552/34736992-c3bb1dba-f542-11e7-840a-782e9bbda9ba.png)
