### PR TITLE
Move flexbox display mode rule next to other display modes

### DIFF
--- a/_lib/solid-utilities/_flexbox.scss
+++ b/_lib/solid-utilities/_flexbox.scss
@@ -4,6 +4,10 @@
 
 @include generate-breakpoint-prefixes {
 
+  // &flex is located in './_layout.scss' so that switching on flexbox
+  // at the smallest breakpoint doesn't override all other display mode
+  // rules due to rule order.
+
   // flex order
   &flex-order-1 { order: 1                               !important; }
   &flex-order-2 { order: 2                               !important; }

--- a/_lib/solid-utilities/_flexbox.scss
+++ b/_lib/solid-utilities/_flexbox.scss
@@ -4,9 +4,6 @@
 
 @include generate-breakpoint-prefixes {
 
-  // flex
-  &flex { display:flex                                   !important; }
-
   // flex order
   &flex-order-1 { order: 1                               !important; }
   &flex-order-2 { order: 2                               !important; }

--- a/_lib/solid-utilities/_layout.scss
+++ b/_lib/solid-utilities/_layout.scss
@@ -19,7 +19,7 @@
   &hide         { display: none         !important; }
   &inline       { display: inline       !important; }
   &block        { display: block        !important; }
-  &flex         { display: flex          !important; }
+  &flex         { display: flex         !important; }
   &inline-block { display: inline-block !important; }
 
   &float-left  { float: left  !important; }

--- a/_lib/solid-utilities/_layout.scss
+++ b/_lib/solid-utilities/_layout.scss
@@ -19,7 +19,7 @@
   &hide         { display: none         !important; }
   &inline       { display: inline       !important; }
   &block        { display: block        !important; }
-  &flex         { display:flex          !important; }
+  &flex         { display: flex          !important; }
   &inline-block { display: inline-block !important; }
 
   &float-left  { float: left  !important; }

--- a/_lib/solid-utilities/_layout.scss
+++ b/_lib/solid-utilities/_layout.scss
@@ -19,6 +19,7 @@
   &hide         { display: none         !important; }
   &inline       { display: inline       !important; }
   &block        { display: block        !important; }
+  &flex         { display:flex          !important; }
   &inline-block { display: inline-block !important; }
 
   &float-left  { float: left  !important; }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bf-solid",
-  "version": "2.10.6",
+  "version": "2.10.7",
   "description": "Solid CSS Styling",
   "scripts": {
     "prepublish": "grunt dist"

--- a/release-notes/2018-02-21-2.10.7.html
+++ b/release-notes/2018-02-21-2.10.7.html
@@ -1,0 +1,12 @@
+---
+category: release-notes
+version: 2.10.7
+title: Display Flexbox Moved
+
+breaking-changes:
+
+potential-breaking-changes:
+
+release-notes:
+- Moved `display: flex` rules alongside other display mode rules
+---


### PR DESCRIPTION
The current ordering means that the `xs-flex` rule is impossible to override with other display modes at larger breakpoints with rules such as `sm-block` etc. Putting the display rule alongside the others should fix this quirk.

Bug: https://codepen.io/jackwreid/pen/qxXwvq