### PR TITLE
OOA11Y-259 make solid checkbox accessible

### DIFF
--- a/_lib/solid-helpers/_variables.scss
+++ b/_lib/solid-helpers/_variables.scss
@@ -104,6 +104,9 @@ $text-tumblr:    #36465d !default;
 $text-youtube:   #FF0000 !default;
 $text-instagram: #000000 !default;
 
+// Interface Colors
+$highlight-outline: #7a9ff3;
+
 // Typography Sizes and Weights
 // -------------------------
 

--- a/_lib/solid-utilities/_forms.scss
+++ b/_lib/solid-utilities/_forms.scss
@@ -143,6 +143,11 @@ select::-ms-expand,
   border-style: none                           !important;
  }
 
+  input:focus + label::before {
+    box-shadow: 0 0 0px 2px $highlight-outline                           !important;
+  }
+
+
 // labels, etc
 // -------------------------
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bf-solid",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "description": "Solid CSS Styling",
   "scripts": {
     "prepublish": "grunt dist"

--- a/release-notes/2019-03-09-2.11.1.html
+++ b/release-notes/2019-03-09-2.11.1.html
@@ -1,0 +1,13 @@
+---
+category: release-notes
+version: 2.11.1
+title: Style updates to checkbox appearance
+
+breaking-changes:
+
+potential-breaking-changes:
+
+release-notes:
+- Added color variable $highlight-outline
+- Used variable to create a new class that highlights the solid checkbox when users use keyboard navigation to highlight elements
+---


### PR DESCRIPTION
This commit adds a blue outline to solid checkboxes when users use tabs to select the checkbox